### PR TITLE
hardening/v0.6.x: strictness waves 1+2, AGPL license, MSRV honesty, gate tightening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,13 @@ jobs:
 
       - uses: taiki-e/install-action@just
 
+      # WHY: `just ci` runs `cargo deny check` and `typos`. Both are
+      # external binaries — neither ships with the Rust toolchain. Using
+      # taiki-e/install-action fetches prebuilt binaries (seconds) rather
+      # than `cargo install` (minutes), which matters on the 3-OS matrix.
+      - uses: taiki-e/install-action@cargo-deny
+      - uses: taiki-e/install-action@typos
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3127,7 +3127,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perima"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "perima-core"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "blake3",
  "proptest",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "perima-db"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "blake3",
  "chrono",
@@ -3185,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "perima-desktop"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "chrono",
  "directories",
@@ -3214,7 +3214,7 @@ dependencies = [
 
 [[package]]
 name = "perima-fs"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "dunce",
  "file-id",
@@ -3234,7 +3234,7 @@ dependencies = [
 
 [[package]]
 name = "perima-hash"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "blake3",
  "perima-core",
@@ -3246,7 +3246,7 @@ dependencies = [
 
 [[package]]
 name = "perima-media"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "blake3",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,11 @@ todo = "deny"
 unimplemented = "deny"
 undocumented_unsafe_blocks = "warn"
 unwrap_used = "warn"
+# Print-macro restrictions (wave 2, 2026-04-20).
+# Per-crate allows cover user-facing CLI output; non-CLI crates must not
+# println!/eprintln! (use tracing instead).
+print_stdout = "warn"
+print_stderr = "warn"
 
 [workspace.dependencies]
 # WHY workspace-path dep for perima-media: release-plz + other crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ dbg_macro = "deny"
 todo = "deny"
 unimplemented = "deny"
 undocumented_unsafe_blocks = "warn"
+unwrap_used = "warn"
 
 [workspace.dependencies]
 # WHY workspace-path dep for perima-media: release-plz + other crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,13 @@ too_many_lines = "warn"
 excessive_nesting = "warn"
 module_name_repetitions = "allow"
 missing_errors_doc = "warn"
+# --- Restriction lints (wave 1, 2026-04-20) ---
+# Zero fires on HEAD; pure forward-insurance against AI-slop patterns.
+# Source: docs/research/rust_strictness.md §1, §6, §8.
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"
+undocumented_unsafe_blocks = "warn"
 
 [workspace.dependencies]
 # WHY workspace-path dep for perima-media: release-plz + other crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/utof/perima"
 missing_docs = "deny"
 unsafe_code = "deny"
 missing_debug_implementations = "warn"
+unreachable_pub = "warn"
 
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/utof/perima"
 [workspace.lints.rust]
 missing_docs = "deny"
 unsafe_code = "deny"
+missing_debug_implementations = "warn"
 
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ resolver = "3"
 [workspace.package]
 version = "0.6.4"
 edition = "2024"
-rust-version = "1.85"
-license = "MIT OR Apache-2.0"
+rust-version = "1.88"
+license = "AGPL-3.0-or-later"
 repository = "https://github.com/utof/perima"
 
 [workspace.lints.rust]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "test": "vitest run",
-    "lint": "eslint src/",
+    "lint": "eslint src/ --max-warnings 0",
     "preview": "vite preview",
     "tauri": "tauri"
   },

--- a/crates/cli/src/cmd/format.rs
+++ b/crates/cli/src/cmd/format.rs
@@ -6,7 +6,7 @@
 /// byte sizes inherently sacrifices precision for readability. A 1-decimal-
 /// place GB figure that is off by a few bytes is correct enough for the UI.
 #[allow(clippy::cast_precision_loss)]
-pub fn format_size(bytes: u64) -> String {
+pub(crate) fn format_size(bytes: u64) -> String {
     const KB: u64 = 1024;
     const MB: u64 = 1024 * KB;
     const GB: u64 = 1024 * MB;

--- a/crates/cli/src/cmd/ls.rs
+++ b/crates/cli/src/cmd/ls.rs
@@ -10,7 +10,7 @@ use perima_core::{
 
 /// Arguments for the ls command.
 #[derive(Debug, Clone)]
-pub struct LsArgs {
+pub(crate) struct LsArgs {
     /// Filter to a specific volume.
     pub volume: Option<VolumeId>,
     /// Maximum number of rows to return.
@@ -40,7 +40,7 @@ pub struct LsArgs {
 ///
 /// # Errors
 /// Propagates `CoreError` from the repository.
-pub fn run<R, M, T>(
+pub(crate) fn run<R, M, T>(
     repo: &R,
     metadata_repo: &M,
     tag_repo: &T,

--- a/crates/cli/src/cmd/metadata.rs
+++ b/crates/cli/src/cmd/metadata.rs
@@ -28,14 +28,14 @@ use tokio_util::sync::CancellationToken;
 /// WHY 3 s: typical image/video extraction completes in well under 500 ms;
 /// 3 s is >5× headroom for slow disks / large files. Longer waits make
 /// `perima metadata` feel unresponsive; shorter waits flake on CI.
-pub const POLL_TIMEOUT: Duration = Duration::from_secs(3);
+pub(crate) const POLL_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Per-iteration backoff while polling for the metadata row.
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Arguments for the metadata command.
 #[derive(Debug, Clone)]
-pub struct MetadataArgs {
+pub(crate) struct MetadataArgs {
     /// Path to the file whose metadata should be re-extracted.
     pub path: PathBuf,
     /// When `true`, emit JSON instead of a human-readable table.
@@ -48,7 +48,11 @@ pub struct MetadataArgs {
 /// Returns [`CoreError::InvalidPath`] when the file does not exist or
 /// is not yet indexed (run `perima scan` first); propagates
 /// [`CoreError`] from volume detection, DB access, and the extractor.
-pub async fn run(data_dir: &Path, device: DeviceId, args: &MetadataArgs) -> Result<(), CoreError> {
+pub(crate) async fn run(
+    data_dir: &Path,
+    device: DeviceId,
+    args: &MetadataArgs,
+) -> Result<(), CoreError> {
     validate_file(&args.path)?;
     let absolute_path = dunce::canonicalize(&args.path).map_err(CoreError::Io)?;
 
@@ -184,7 +188,7 @@ fn validate_file(path: &Path) -> Result<(), CoreError> {
 /// without duplicating the suffix-match logic. The enclosing `cmd`
 /// module is private to the crate binary, so `pub` here is effectively
 /// crate-private.
-pub fn find_by_absolute_suffix<'a>(
+pub(crate) fn find_by_absolute_suffix<'a>(
     records: &'a [FileLocationRecord],
     absolute: &str,
 ) -> Option<&'a FileLocationRecord> {

--- a/crates/cli/src/cmd/metadata.rs
+++ b/crates/cli/src/cmd/metadata.rs
@@ -66,7 +66,7 @@ pub async fn run(data_dir: &Path, device: DeviceId, args: &MetadataArgs) -> Resu
     // under WAL mode a fresh open is ~microseconds. Sharing a single
     // connection across repos would require wrapping it in another layer
     // of `Mutex`, which none of the repos' `new(...)` constructors accept.
-    let mut vol_repo = SqliteVolumeRepository::new(open_and_migrate(&db_path)?);
+    let vol_repo = SqliteVolumeRepository::new(open_and_migrate(&db_path)?);
     let volume_id = vol_repo.find_or_create(&detected.identifiers, device)?;
     drop(vol_repo);
 

--- a/crates/cli/src/cmd/mod.rs
+++ b/crates/cli/src/cmd/mod.rs
@@ -1,10 +1,10 @@
 //! CLI subcommand modules.
 
-pub mod format;
-pub mod ls;
-pub mod metadata;
-pub mod scan;
-pub mod search;
-pub mod tag;
-pub mod volumes;
-pub mod watch;
+pub(crate) mod format;
+pub(crate) mod ls;
+pub(crate) mod metadata;
+pub(crate) mod scan;
+pub(crate) mod search;
+pub(crate) mod tag;
+pub(crate) mod volumes;
+pub(crate) mod watch;

--- a/crates/cli/src/cmd/scan.rs
+++ b/crates/cli/src/cmd/scan.rs
@@ -414,7 +414,7 @@ where
 /// location record. Returns the location outcome so the caller can
 /// classify the result as new/existing.
 fn persist_file<R: FileRepository + ?Sized>(
-    repo: &mut R,
+    repo: &R,
     d: &DiscoveredFile,
     h: &BlakeHash,
     device: DeviceId,

--- a/crates/cli/src/cmd/scan.rs
+++ b/crates/cli/src/cmd/scan.rs
@@ -284,23 +284,21 @@ where
                             // would do identical work. If the user wants
                             // a forced re-extract they can call
                             // `perima metadata <path>`.
-                            if matches!(outcome, UpsertOutcome::Inserted | UpsertOutcome::Updated) {
-                                if let Some(q) = queue.as_ref() {
-                                    if let Err(e) =
-                                        q.enqueue(h, d.absolute_path.clone(), &cancel.token())
-                                    {
-                                        // WHY log + continue: the plan is
-                                        // explicit that a metadata-queue
-                                        // failure must not abort the scan.
-                                        // The user can always re-run or
-                                        // `perima metadata` for stragglers.
-                                        tracing::warn!(
-                                            error = %e,
-                                            path = %d.absolute_path.display(),
-                                            "metadata enqueue failed; continuing scan",
-                                        );
-                                    }
-                                }
+                            if matches!(outcome, UpsertOutcome::Inserted | UpsertOutcome::Updated)
+                                && let Some(q) = queue.as_ref()
+                                && let Err(e) =
+                                    q.enqueue(h, d.absolute_path.clone(), &cancel.token())
+                            {
+                                // WHY log + continue: the plan is
+                                // explicit that a metadata-queue
+                                // failure must not abort the scan.
+                                // The user can always re-run or
+                                // `perima metadata` for stragglers.
+                                tracing::warn!(
+                                    error = %e,
+                                    path = %d.absolute_path.display(),
+                                    "metadata enqueue failed; continuing scan",
+                                );
                             }
                             manifest_files.push(HashedFile {
                                 discovered: d,

--- a/crates/cli/src/cmd/scan.rs
+++ b/crates/cli/src/cmd/scan.rs
@@ -24,7 +24,7 @@ use crate::signals::Cancellation;
 /// tests use to complete comfortably, short enough that Ctrl-C remains
 /// responsive (the drain also polls cancel). `--no-wait-metadata`
 /// bypasses this when the user wants fast scan exit.
-pub const METADATA_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const METADATA_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Arguments for the scan command.
 // WHY allow(struct_excessive_bools): each flag corresponds to a
@@ -34,7 +34,7 @@ pub const METADATA_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
 // Per plan the flags stay individually named.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
-pub struct ScanArgs {
+pub(crate) struct ScanArgs {
     /// Root directory to walk.
     pub root: PathBuf,
     /// When true, hashes and prints but skips all DB writes.
@@ -61,7 +61,7 @@ pub struct ScanArgs {
 
 /// Scan statistics.
 #[derive(Debug, Clone, Copy, Default)]
-pub struct ScanStats {
+pub(crate) struct ScanStats {
     /// Files newly indexed.
     pub new: u64,
     /// Files already present (unchanged or updated).
@@ -72,7 +72,7 @@ pub struct ScanStats {
 
 /// Exit code returned to `main`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ExitCode {
+pub(crate) enum ExitCode {
     /// Completed normally.
     Success,
     /// Ctrl-C received; partial scan summarized.
@@ -84,7 +84,7 @@ pub enum ExitCode {
 ///
 /// WHY type alias: the full `Option<&dyn Fn(...)>` signature trips
 /// `clippy::type_complexity`; a named alias keeps the `run` signature readable.
-pub type OnPersistFn<'a> = Option<&'a dyn Fn(&MediaPath, VolumeId, DeviceId)>;
+pub(crate) type OnPersistFn<'a> = Option<&'a dyn Fn(&MediaPath, VolumeId, DeviceId)>;
 
 /// Execute `scan`.
 ///
@@ -132,7 +132,7 @@ pub type OnPersistFn<'a> = Option<&'a dyn Fn(&MediaPath, VolumeId, DeviceId)>;
 #[allow(clippy::too_many_lines)]
 #[allow(clippy::future_not_send)]
 #[allow(clippy::cognitive_complexity)]
-pub async fn run<S, H, FR, VR>(
+pub(crate) async fn run<S, H, FR, VR>(
     scanner: &S,
     hasher: &H,
     mut file_repo: Option<&mut FR>,

--- a/crates/cli/src/cmd/search.rs
+++ b/crates/cli/src/cmd/search.rs
@@ -4,7 +4,7 @@ use perima_core::{CoreError, SearchRepository};
 
 /// Arguments for the `perima search` command.
 #[derive(clap::Args, Debug)]
-pub struct SearchArgs {
+pub(crate) struct SearchArgs {
     /// `FTS5` match expression (e.g. `"vacation"`, `"image/jpeg"`, `"Canon*"`).
     ///
     /// Required unless `--rebuild` is specified.
@@ -33,7 +33,7 @@ pub struct SearchArgs {
 /// # Errors
 /// Returns [`CoreError::Internal`] on DB/`FTS5` errors.
 /// Returns [`CoreError::Unsupported`] when no query is supplied without `--rebuild`.
-pub fn run<S>(repo: &S, args: &SearchArgs) -> Result<(), CoreError>
+pub(crate) fn run<S>(repo: &S, args: &SearchArgs) -> Result<(), CoreError>
 where
     S: SearchRepository + ?Sized,
 {

--- a/crates/cli/src/cmd/tag.rs
+++ b/crates/cli/src/cmd/tag.rs
@@ -14,7 +14,7 @@ use super::metadata::find_by_absolute_suffix;
 
 /// Arguments for the `perima tag` command.
 #[derive(clap::Args, Debug)]
-pub struct TagArgs {
+pub(crate) struct TagArgs {
     /// The tag sub-action to perform.
     #[command(subcommand)]
     pub action: TagAction,
@@ -22,7 +22,7 @@ pub struct TagArgs {
 
 /// Individual actions available under `perima tag`.
 #[derive(clap::Subcommand, Debug)]
-pub enum TagAction {
+pub(crate) enum TagAction {
     /// Attach one or more labels to a file.
     Add {
         /// Path to the file to tag.
@@ -58,7 +58,7 @@ pub enum TagAction {
 /// Returns [`CoreError::InvalidPath`] when the file does not exist or
 /// is not yet indexed (run `perima scan` first); propagates
 /// [`CoreError`] from tag normalization, DB access, and I/O.
-pub fn run<T, F>(
+pub(crate) fn run<T, F>(
     tag_repo: &T,
     file_repo: &F,
     device: DeviceId,

--- a/crates/cli/src/cmd/tag.rs
+++ b/crates/cli/src/cmd/tag.rs
@@ -29,7 +29,7 @@ pub(crate) enum TagAction {
         path: PathBuf,
         /// One or more tag names to attach.
         ///
-        /// WHY required + 1..: clap's default for Vec<T> is "zero or
+        /// WHY required + 1..: clap's default for `Vec<T>` is "zero or
         /// more positionals" — `perima tag add foo.jpg` would silently
         /// no-op. Force at least one tag argument so the error is a
         /// clear "missing required tag" message instead of success-

--- a/crates/cli/src/cmd/volumes.rs
+++ b/crates/cli/src/cmd/volumes.rs
@@ -14,7 +14,7 @@ use super::format::format_size;
 ///
 /// # Errors
 /// Propagates `CoreError` from the repository.
-pub fn run<VR: VolumeRepository>(repo: &VR, machine: DeviceId) -> Result<(), CoreError> {
+pub(crate) fn run<VR: VolumeRepository>(repo: &VR, machine: DeviceId) -> Result<(), CoreError> {
     let records = repo.list(machine)?;
 
     let stdout = std::io::stdout();

--- a/crates/cli/src/cmd/watch.rs
+++ b/crates/cli/src/cmd/watch.rs
@@ -30,14 +30,14 @@ use crate::signals::Cancellation;
 /// which requires the `tracing` crate. `crates/core` deliberately has zero
 /// framework dependencies, so the composite lives in the CLI shell where
 /// `tracing` is already a direct dependency.
-pub struct CompositeEventBus {
+pub(crate) struct CompositeEventBus {
     handlers: Vec<Arc<dyn EventBus>>,
 }
 
 impl CompositeEventBus {
     /// Construct from a list of handlers.
     #[must_use]
-    pub fn new(handlers: Vec<Arc<dyn EventBus>>) -> Self {
+    pub(crate) fn new(handlers: Vec<Arc<dyn EventBus>>) -> Self {
         Self { handlers }
     }
 }
@@ -181,7 +181,7 @@ fn canonicalize(root: &Path) -> Result<PathBuf, CoreError> {
 /// # Errors
 /// Returns [`CoreError::InvalidPath`] if `root` is not an existing directory;
 /// propagates [`CoreError`] from volume detection, DB access, or watcher init.
-pub async fn run(
+pub(crate) async fn run(
     data_dir: &Path,
     device_id: DeviceId,
     root: &Path,

--- a/crates/cli/src/cmd/watch.rs
+++ b/crates/cli/src/cmd/watch.rs
@@ -199,7 +199,7 @@ pub async fn run(
     let vol_conn = open_and_migrate(&db_path)?;
     let file_conn = open_and_migrate(&db_path)?;
 
-    let mut vol_repo = SqliteVolumeRepository::new(vol_conn);
+    let vol_repo = SqliteVolumeRepository::new(vol_conn);
     let volume_id = vol_repo.find_or_create(&detected.identifiers, device_id)?;
     vol_repo.record_mount(volume_id, device_id, &detected.mount_point)?;
     drop(vol_repo);

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -12,7 +12,7 @@ use perima_core::{CoreError, DeviceId, ids};
 // regardless of the field name choice here.
 #[allow(clippy::struct_field_names)]
 #[derive(Clone, Debug)]
-pub struct Config {
+pub(crate) struct Config {
     /// Where the main database will live (1b uses this).
     // WHY allow dead_code: `data_dir`, `config_dir`, and `device_id`
     // are forwarded to the DB layer in phase 1b; declaring them here
@@ -36,7 +36,7 @@ impl Config {
     /// # Errors
     /// Returns `CoreError::Internal` if platform directories cannot
     /// be resolved, or `CoreError::Io` on filesystem failures.
-    pub fn resolve(cli_data_dir: Option<PathBuf>) -> Result<Self, CoreError> {
+    pub(crate) fn resolve(cli_data_dir: Option<PathBuf>) -> Result<Self, CoreError> {
         let dirs = directories::ProjectDirs::from("dev", "perima", "perima")
             .ok_or_else(|| CoreError::Internal("cannot resolve project dirs".into()))?;
 

--- a/crates/cli/src/logging.rs
+++ b/crates/cli/src/logging.rs
@@ -11,7 +11,7 @@ use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 /// # Errors
 /// Returns `CoreError::Internal` if the global subscriber is already
 /// set (tests should tolerate this).
-pub fn init(verbosity_bump: u8) -> Result<(), CoreError> {
+pub(crate) fn init(verbosity_bump: u8) -> Result<(), CoreError> {
     let base = std::env::var("PERIMA_LOG").unwrap_or_else(|_| "info".into());
     let bump_level = match verbosity_bump {
         0 => None,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -6,12 +6,16 @@
     clippy::print_stderr,
     reason = "CLI's purpose is user-facing output to stdout/stderr. Migrate to `tracing` for structured logs in a future wave; user-facing output stays on println!/eprintln!."
 )]
+#![allow(
+    clippy::redundant_pub_crate,
+    reason = "Binary crate: modules are pub(crate) to satisfy unreachable_pub; items inside are also pub(crate) for explicit scope signaling. redundant_pub_crate fires on pub(crate)-inside-pub(crate) but the intent is explicit, not accidental."
+)]
 
-mod cmd;
-mod config;
-mod logging;
-mod panic;
-mod signals;
+pub(crate) mod cmd;
+pub(crate) mod config;
+pub(crate) mod logging;
+pub(crate) mod panic;
+pub(crate) mod signals;
 
 use std::path::PathBuf;
 use std::process::ExitCode;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8,14 +8,14 @@
 )]
 #![allow(
     clippy::redundant_pub_crate,
-    reason = "Binary crate: modules are pub(crate) to satisfy unreachable_pub; items inside are also pub(crate) for explicit scope signaling. redundant_pub_crate fires on pub(crate)-inside-pub(crate) but the intent is explicit, not accidental."
+    reason = "Binary crate. clippy::nursery::redundant_pub_crate fires on pub(crate) items inside private `mod` blocks because pub(crate) is technically redundant there (the private mod already restricts visibility). We keep items pub(crate) anyway for explicit scope signalling and suppress the nursery lint crate-wide."
 )]
 
-pub(crate) mod cmd;
-pub(crate) mod config;
-pub(crate) mod logging;
-pub(crate) mod panic;
-pub(crate) mod signals;
+mod cmd;
+mod config;
+mod logging;
+mod panic;
+mod signals;
 
 use std::path::PathBuf;
 use std::process::ExitCode;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,6 +1,11 @@
 //! `perima` command-line entry point.
 
 #![forbid(unsafe_code)]
+#![allow(
+    clippy::print_stdout,
+    clippy::print_stderr,
+    reason = "CLI's purpose is user-facing output to stdout/stderr. Migrate to `tracing` for structured logs in a future wave; user-facing output stays on println!/eprintln!."
+)]
 
 mod cmd;
 mod config;

--- a/crates/cli/src/panic.rs
+++ b/crates/cli/src/panic.rs
@@ -4,7 +4,7 @@
 /// `tracing::error!` with thread info. Replaces the default
 /// "thread 'xxx' panicked at …" so background rayon threads don't
 /// die silently.
-pub fn install() {
+pub(crate) fn install() {
     let default_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         let thread = std::thread::current();

--- a/crates/cli/src/signals.rs
+++ b/crates/cli/src/signals.rs
@@ -10,14 +10,14 @@ use tokio_util::sync::CancellationToken;
 /// `CancellationToken` is the idiomatic tokio-util primitive for this;
 /// it is cheaply cloneable and integrates with tokio's `select!` and
 /// `CancellationToken::cancelled_owned()` futures.
-pub struct Cancellation {
+pub(crate) struct Cancellation {
     token: CancellationToken,
 }
 
 impl Cancellation {
     /// Has a cancellation signal been received?
     #[must_use]
-    pub fn cancelled(&self) -> bool {
+    pub(crate) fn cancelled(&self) -> bool {
         self.token.is_cancelled()
     }
 
@@ -28,7 +28,7 @@ impl Cancellation {
     /// inner handle, so `clone()` is O(1) and the clone shares state with the
     /// original. Callers that only need a boolean should prefer `cancelled()`.
     #[must_use]
-    pub fn token(&self) -> CancellationToken {
+    pub(crate) fn token(&self) -> CancellationToken {
         self.token.clone()
     }
 }
@@ -44,7 +44,7 @@ impl Cancellation {
 /// # Errors
 /// Returns `CoreError::Internal` if another handler is already registered
 /// (only one `ctrlc` handler per process).
-pub fn install() -> Result<Cancellation, CoreError> {
+pub(crate) fn install() -> Result<Cancellation, CoreError> {
     let token = CancellationToken::new();
     let cloned = token.clone();
     ctrlc::set_handler(move || {

--- a/crates/core/src/ports/file_repo.rs
+++ b/crates/core/src/ports/file_repo.rs
@@ -12,11 +12,7 @@ pub trait FileRepository: Send + Sync {
     /// # Errors
     /// Adapter-level errors are surfaced as `CoreError::Internal`
     /// unless they map to a typed variant.
-    fn upsert_file(
-        &mut self,
-        file: &HashedFile,
-        device: DeviceId,
-    ) -> Result<UpsertOutcome, CoreError>;
+    fn upsert_file(&self, file: &HashedFile, device: DeviceId) -> Result<UpsertOutcome, CoreError>;
 
     /// Upsert a `file_locations` row for `(volume, relative_path)`.
     ///
@@ -24,7 +20,7 @@ pub trait FileRepository: Send + Sync {
     /// Returns `CoreError::Duplicate` if the app-level uniqueness
     /// check rejects the row.
     fn upsert_location(
-        &mut self,
+        &self,
         hash: &BlakeHash,
         volume: VolumeId,
         path: &MediaPath,

--- a/crates/core/src/ports/volume_repo.rs
+++ b/crates/core/src/ports/volume_repo.rs
@@ -12,7 +12,7 @@ pub trait VolumeRepository: Send + Sync {
     /// # Errors
     /// `CoreError::Internal` on adapter failure.
     fn find_or_create(
-        &mut self,
+        &self,
         ident: &VolumeIdentifiers,
         device: DeviceId,
     ) -> Result<VolumeId, CoreError>;
@@ -22,7 +22,7 @@ pub trait VolumeRepository: Send + Sync {
     /// # Errors
     /// `CoreError::Internal` on adapter failure.
     fn record_mount(
-        &mut self,
+        &self,
         volume: VolumeId,
         machine: DeviceId,
         mount: &Path,

--- a/crates/core/src/tag.rs
+++ b/crates/core/src/tag.rs
@@ -50,6 +50,10 @@ pub fn normalize(raw: &str) -> Result<String, CoreError> {
     Ok(normalized)
 }
 
+#[allow(
+    clippy::unwrap_used,
+    reason = "tests: unwrap is the assertion — a panic is a failing test by design"
+)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -338,9 +338,9 @@ mod tests {
     #[test]
     fn media_path_nfc_equivalence_fixed() {
         // "café" — precomposed (NFC) vs decomposed (NFD).
-        let nfc = "caf\u{00E9}";
-        let nfd = "cafe\u{0301}";
-        assert_eq!(MediaPath::new(nfc), MediaPath::new(nfd));
+        let precomposed = "caf\u{00E9}";
+        let decomposed = "cafe\u{0301}";
+        assert_eq!(MediaPath::new(precomposed), MediaPath::new(decomposed));
     }
 
     #[test]

--- a/crates/db/src/file_repo.rs
+++ b/crates/db/src/file_repo.rs
@@ -538,7 +538,7 @@ mod tests {
         let f1 = sample_hashed_file(b"hello", "a.txt");
         repo.upsert_file(&f1, dev).expect("first");
         // Same hash, different size (contrived but tests the branch).
-        let mut f2 = f1.clone();
+        let mut f2 = f1;
         f2.discovered.size = FileSize(999);
         let out = repo.upsert_file(&f2, dev).expect("second");
         assert_eq!(out, UpsertOutcome::Updated);

--- a/crates/db/src/file_repo.rs
+++ b/crates/db/src/file_repo.rs
@@ -263,11 +263,7 @@ impl SqliteFileRepository {
 }
 
 impl FileRepository for SqliteFileRepository {
-    fn upsert_file(
-        &mut self,
-        file: &HashedFile,
-        device: DeviceId,
-    ) -> Result<UpsertOutcome, CoreError> {
+    fn upsert_file(&self, file: &HashedFile, device: DeviceId) -> Result<UpsertOutcome, CoreError> {
         // WHY: PoisonError can only occur if a thread panicked while holding
         // the lock. In that case the DB state is unknown; propagate as Internal.
         let conn = self
@@ -321,7 +317,7 @@ impl FileRepository for SqliteFileRepository {
     }
 
     fn upsert_location(
-        &mut self,
+        &self,
         hash: &BlakeHash,
         volume: VolumeId,
         path: &MediaPath,
@@ -519,7 +515,7 @@ mod tests {
 
     #[test]
     fn upsert_file_inserts_new() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let f = sample_hashed_file(b"hello", "a.txt");
         let out = repo.upsert_file(&f, device()).expect("upsert");
         assert_eq!(out, UpsertOutcome::Inserted);
@@ -527,7 +523,7 @@ mod tests {
 
     #[test]
     fn upsert_file_unchanged_on_repeat() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let f = sample_hashed_file(b"hello", "a.txt");
         repo.upsert_file(&f, dev).expect("first");
@@ -537,7 +533,7 @@ mod tests {
 
     #[test]
     fn upsert_file_updated_on_size_change() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let f1 = sample_hashed_file(b"hello", "a.txt");
         repo.upsert_file(&f1, dev).expect("first");
@@ -550,7 +546,7 @@ mod tests {
 
     #[test]
     fn upsert_location_inserts_new() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let f = sample_hashed_file(b"hello", "a.txt");
         repo.upsert_file(&f, dev).expect("file");
@@ -562,7 +558,7 @@ mod tests {
 
     #[test]
     fn upsert_location_unchanged_on_repeat() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let f = sample_hashed_file(b"hello", "a.txt");
         repo.upsert_file(&f, dev).expect("file");
@@ -578,7 +574,7 @@ mod tests {
 
     #[test]
     fn upsert_location_updated_on_hash_change() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let f1 = sample_hashed_file(b"hello", "a.txt");
         let f2 = sample_hashed_file(b"world", "a.txt");
@@ -596,7 +592,7 @@ mod tests {
 
     #[test]
     fn list_file_locations_returns_all() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let vol = sentinel_volume();
         for (i, name) in ["a.txt", "b.txt", "c.txt"].iter().enumerate() {
@@ -614,7 +610,7 @@ mod tests {
 
     #[test]
     fn list_file_locations_respects_limit() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let vol = sentinel_volume();
         for i in 0..5 {
@@ -629,7 +625,7 @@ mod tests {
 
     #[test]
     fn list_file_locations_filters_by_volume() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let vol_a = VolumeId::new();
         let vol_b = VolumeId::new();
@@ -648,7 +644,7 @@ mod tests {
 
     #[test]
     fn migrate_sentinel_row_updates_volume_id() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let sentinel = sentinel_volume();
         let real_vol = VolumeId::new();
@@ -685,7 +681,7 @@ mod tests {
 
     #[test]
     fn migrate_sentinel_row_skips_non_sentinel() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let real_vol = VolumeId::new();
         let other_vol = VolumeId::new();
@@ -707,7 +703,7 @@ mod tests {
 
     #[test]
     fn update_status_to_missing() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let vol = VolumeId::new();
         let f = sample_hashed_file(b"missing_test", "img.jpg");
@@ -733,7 +729,7 @@ mod tests {
 
     #[test]
     fn update_status_to_stale() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let vol = VolumeId::new();
         let f = sample_hashed_file(b"stale_test", "doc.txt");
@@ -756,7 +752,7 @@ mod tests {
 
     #[test]
     fn update_location_path_renames() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let vol = VolumeId::new();
         let f = sample_hashed_file(b"rename_test", "old_name.jpg");
@@ -791,7 +787,7 @@ mod tests {
         // filesystem already has a file at new_path). Observable:
         // list_file_locations shows exactly the destination row, with the
         // destination's original hash untouched.
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let vol = VolumeId::new();
 
@@ -836,7 +832,7 @@ mod tests {
         // 1b edit. A plain rename (no active row at new_path) must update
         // the row in place and keep exactly one active row with the new
         // path and active status.
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let vol = VolumeId::new();
         let f = sample_hashed_file(b"normal_rename", "a.jpg");
@@ -879,7 +875,7 @@ mod tests {
         // Seed the files row so both threads can link a location to it.
         {
             let conn = open_and_migrate(&db_path).expect("seed open");
-            let mut seed = SqliteFileRepository::new(conn);
+            let seed = SqliteFileRepository::new(conn);
             let f = sample_hashed_file(b"shared", "race.jpg");
             seed.upsert_file(&f, dev).expect("seed file");
         }
@@ -894,7 +890,7 @@ mod tests {
             let path = f.discovered.relative_path.clone();
             handles.push(thread::spawn(move || {
                 let conn = open_and_migrate(&db_path).expect("open");
-                let mut repo = SqliteFileRepository::new(conn);
+                let repo = SqliteFileRepository::new(conn);
                 barrier.wait();
                 repo.upsert_location(&hash, vol, &path, dev)
                     .expect("upsert_location")

--- a/crates/db/src/file_repo.rs
+++ b/crates/db/src/file_repo.rs
@@ -24,6 +24,13 @@ pub struct SqliteFileRepository {
     conn: Mutex<Connection>,
 }
 
+impl std::fmt::Debug for SqliteFileRepository {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SqliteFileRepository")
+            .finish_non_exhaustive()
+    }
+}
+
 impl SqliteFileRepository {
     /// Wrap an existing connection. The caller must have run
     /// migrations before constructing this.

--- a/crates/db/src/metadata_repo.rs
+++ b/crates/db/src/metadata_repo.rs
@@ -32,6 +32,13 @@ pub struct SqliteMetadataRepository {
     conn: Mutex<Connection>,
 }
 
+impl std::fmt::Debug for SqliteMetadataRepository {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SqliteMetadataRepository")
+            .finish_non_exhaustive()
+    }
+}
+
 impl SqliteMetadataRepository {
     /// Wrap an existing connection. The caller must have run
     /// migrations (at least V001 + V002) before constructing this.

--- a/crates/db/src/metadata_repo.rs
+++ b/crates/db/src/metadata_repo.rs
@@ -782,7 +782,7 @@ mod tests {
 
         {
             let conn = open_and_migrate(&db_path).expect("open");
-            let mut file_repo = SqliteFileRepository::new(conn);
+            let file_repo = SqliteFileRepository::new(conn);
             file_repo.upsert_file(&f, dev).expect("upsert file");
             file_repo
                 .upsert_location(&f.hash, vol, &f.discovered.relative_path, dev)
@@ -819,7 +819,7 @@ mod tests {
 
         {
             let conn = open_and_migrate(&db_path).expect("open");
-            let mut file_repo = SqliteFileRepository::new(conn);
+            let file_repo = SqliteFileRepository::new(conn);
             file_repo.upsert_file(&f, dev).expect("upsert file");
             file_repo
                 .upsert_location(&f.hash, vol, &f.discovered.relative_path, dev)

--- a/crates/db/src/search_repo.rs
+++ b/crates/db/src/search_repo.rs
@@ -1637,7 +1637,7 @@ mod tests {
                     |r| r.get(0),
                 )
                 .expect("rep path");
-            let (mime, cam, cap): (String, String, String) = conn
+            let (mime, camera, captured): (String, String, String) = conn
                 .query_row(
                     "SELECT COALESCE(mime_type, ''),
                             COALESCE(camera_model, ''),
@@ -1670,8 +1670,8 @@ mod tests {
                 blake3_hash: h,
                 relative_path: path.clone(),
                 mime_type: mime,
-                camera_model: cam,
-                captured_at: cap,
+                camera_model: camera,
+                captured_at: captured,
                 tags: tag_names.join(" "),
             });
         }

--- a/crates/db/src/search_repo.rs
+++ b/crates/db/src/search_repo.rs
@@ -17,6 +17,13 @@ pub struct SqliteSearchRepository {
     conn: Mutex<Connection>,
 }
 
+impl std::fmt::Debug for SqliteSearchRepository {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SqliteSearchRepository")
+            .finish_non_exhaustive()
+    }
+}
+
 impl SqliteSearchRepository {
     /// Wrap an existing connection. Caller must have run migrations
     /// through V007 before constructing this.

--- a/crates/db/src/tag_repo.rs
+++ b/crates/db/src/tag_repo.rs
@@ -23,6 +23,13 @@ pub struct SqliteTagRepository {
     conn: Mutex<Connection>,
 }
 
+impl std::fmt::Debug for SqliteTagRepository {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SqliteTagRepository")
+            .finish_non_exhaustive()
+    }
+}
+
 impl SqliteTagRepository {
     /// Wrap an existing connection. Caller must have run migrations
     /// (at least through V005) before constructing this.

--- a/crates/db/src/tag_repo.rs
+++ b/crates/db/src/tag_repo.rs
@@ -381,6 +381,10 @@ impl TagRepository for SqliteTagRepository {
     }
 }
 
+#[allow(
+    clippy::unwrap_used,
+    reason = "tests: unwrap is the assertion — a panic is a failing test by design"
+)]
 #[cfg(test)]
 mod tests {
     use std::sync::{Arc, Barrier};

--- a/crates/db/src/volume_repo.rs
+++ b/crates/db/src/volume_repo.rs
@@ -43,7 +43,7 @@ fn lock(conn: &Mutex<Connection>) -> Result<std::sync::MutexGuard<'_, Connection
 
 impl VolumeRepository for SqliteVolumeRepository {
     fn find_or_create(
-        &mut self,
+        &self,
         ident: &VolumeIdentifiers,
         device: DeviceId,
     ) -> Result<VolumeId, CoreError> {
@@ -174,7 +174,7 @@ impl VolumeRepository for SqliteVolumeRepository {
     }
 
     fn record_mount(
-        &mut self,
+        &self,
         volume: VolumeId,
         machine: DeviceId,
         mount: &std::path::Path,
@@ -353,7 +353,7 @@ mod tests {
 
     #[test]
     fn find_or_create_inserts_new() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let ident = label_cap_ident("MY_DRIVE", 1_000_000);
         let vol_id = repo
             .find_or_create(&ident, device())
@@ -364,7 +364,7 @@ mod tests {
 
     #[test]
     fn find_or_create_matches_on_label_capacity() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let ident = label_cap_ident("BACKUP_SSD", 2_000_000_000);
         let first = repo.find_or_create(&ident, dev).expect("first");
@@ -377,7 +377,7 @@ mod tests {
 
     #[test]
     fn find_or_create_guid_trumps_label() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
 
         // Insert volume A with GUID "aaa…" + label "A".
@@ -412,7 +412,7 @@ mod tests {
 
     #[test]
     fn record_mount_inserts_new() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let ident = label_cap_ident("MOUNT_TEST", 100_000);
         let vol_id = repo.find_or_create(&ident, dev).expect("create");
@@ -429,7 +429,7 @@ mod tests {
 
     #[test]
     fn record_mount_unchanged_on_repeat() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let ident = label_cap_ident("MOUNT_REPEAT", 200_000);
         let vol_id = repo.find_or_create(&ident, dev).expect("create");
@@ -471,7 +471,7 @@ mod tests {
             let barrier = Arc::clone(&barrier);
             handles.push(thread::spawn(move || -> VolumeId {
                 let conn = open_and_migrate(&db_path).expect("open");
-                let mut repo = SqliteVolumeRepository::new(conn);
+                let repo = SqliteVolumeRepository::new(conn);
                 let ident = label_cap_ident("RACE_VOL", 42_000);
                 barrier.wait();
                 repo.find_or_create(&ident, dev).expect("find_or_create")
@@ -509,7 +509,7 @@ mod tests {
         // soft-delete the prior row rather than leaving two active mount
         // rows for one device. `list` reads only active mounts, so the
         // observable contract is: after remount only the new path surfaces.
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let ident = label_cap_ident("SUPERSEDE", 100_000);
         let vol_id = repo.find_or_create(&ident, dev).expect("create");
@@ -535,7 +535,7 @@ mod tests {
         // churn the row and update updated_at. Explicit test to pin the
         // "idempotent" behaviour beyond `record_mount_unchanged_on_repeat`
         // which only asserts the list count.
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let ident = label_cap_ident("IDEMPOTENT", 50_000);
         let vol_id = repo.find_or_create(&ident, dev).expect("create");
@@ -565,7 +565,7 @@ mod tests {
         use std::os::unix::ffi::OsStringExt;
         use std::path::PathBuf;
 
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let ident = label_cap_ident("NONUTF8", 100_000);
         let vol_id = repo.find_or_create(&ident, dev).expect("create");
@@ -584,7 +584,7 @@ mod tests {
 
     #[test]
     fn list_returns_volumes_with_mounts() {
-        let (_td, mut repo) = test_db();
+        let (_td, repo) = test_db();
         let dev = device();
         let ident = label_cap_ident("LIST_TEST", 999_000);
         let vol_id = repo.find_or_create(&ident, dev).expect("create");

--- a/crates/db/src/volume_repo.rs
+++ b/crates/db/src/volume_repo.rs
@@ -22,6 +22,13 @@ pub struct SqliteVolumeRepository {
     conn: Mutex<Connection>,
 }
 
+impl std::fmt::Debug for SqliteVolumeRepository {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SqliteVolumeRepository")
+            .finish_non_exhaustive()
+    }
+}
+
 impl SqliteVolumeRepository {
     /// Wrap an existing connection. Caller must have run migrations first.
     pub const fn new(conn: Connection) -> Self {

--- a/crates/desktop/src/commands.rs
+++ b/crates/desktop/src/commands.rs
@@ -348,8 +348,8 @@ pub async fn run_scan_inner_with_metadata(
     let vol_conn = open_and_migrate(&db_path)?;
     let sentinel_conn = open_and_migrate(&db_path)?;
 
-    let mut file_repo = SqliteFileRepository::new(file_conn);
-    let mut vol_repo = SqliteVolumeRepository::new(vol_conn);
+    let file_repo = SqliteFileRepository::new(file_conn);
+    let vol_repo = SqliteVolumeRepository::new(vol_conn);
     let sentinel_repo = SqliteFileRepository::new(sentinel_conn);
 
     let on_persist = |path: &perima_core::MediaPath, volume: VolumeId, dev: DeviceId| {
@@ -369,8 +369,8 @@ pub async fn run_scan_inner_with_metadata(
     run_scan_live(
         &scanner,
         &hasher,
-        &mut file_repo,
-        &mut vol_repo,
+        &file_repo,
+        &vol_repo,
         Some(&on_persist),
         device_id,
         &canonical_root,
@@ -546,15 +546,12 @@ pub async fn start_watch(
     let vol_conn = open_and_migrate(&db_path).map_err(|e| e.to_string())?;
     let file_conn = open_and_migrate(&db_path).map_err(|e| e.to_string())?;
 
-    let mut vol_repo = SqliteVolumeRepository::new(vol_conn);
-    let volume_id = perima_core::VolumeRepository::find_or_create(
-        &mut vol_repo,
-        &detected.identifiers,
-        device_id,
-    )
-    .map_err(|e| e.to_string())?;
+    let vol_repo = SqliteVolumeRepository::new(vol_conn);
+    let volume_id =
+        perima_core::VolumeRepository::find_or_create(&vol_repo, &detected.identifiers, device_id)
+            .map_err(|e| e.to_string())?;
     perima_core::VolumeRepository::record_mount(
-        &mut vol_repo,
+        &vol_repo,
         volume_id,
         device_id,
         &detected.mount_point,
@@ -920,8 +917,8 @@ where
 async fn run_scan_live<S, H, FR, VR>(
     scanner: &S,
     hasher: &H,
-    file_repo: &mut FR,
-    volume_repo: &mut VR,
+    file_repo: &FR,
+    volume_repo: &VR,
     on_persist: OnPersistFn<'_>,
     device_id: DeviceId,
     canonical_root: &Path,
@@ -1004,16 +1001,14 @@ where
                     if matches!(
                         outcome,
                         perima_core::UpsertOutcome::Inserted | perima_core::UpsertOutcome::Updated
-                    ) {
-                        if let Some(q) = queue.as_ref() {
-                            if let Err(e) = q.enqueue(h, d.absolute_path.clone(), &queue_cancel) {
-                                tracing::warn!(
-                                    error = %e,
-                                    path = %d.absolute_path.display(),
-                                    "metadata enqueue failed; continuing scan",
-                                );
-                            }
-                        }
+                    ) && let Some(q) = queue.as_ref()
+                        && let Err(e) = q.enqueue(h, d.absolute_path.clone(), &queue_cancel)
+                    {
+                        tracing::warn!(
+                            error = %e,
+                            path = %d.absolute_path.display(),
+                            "metadata enqueue failed; continuing scan",
+                        );
                     }
                     manifest_files.push(perima_core::HashedFile {
                         discovered: d,
@@ -1068,7 +1063,7 @@ where
 }
 
 fn persist_file<R: perima_core::FileRepository + ?Sized>(
-    repo: &mut R,
+    repo: &R,
     d: &perima_core::DiscoveredFile,
     h: &perima_core::BlakeHash,
     device: DeviceId,

--- a/crates/desktop/src/events.rs
+++ b/crates/desktop/src/events.rs
@@ -94,6 +94,12 @@ pub struct TauriEventEmitter {
     pub app_handle: AppHandle,
 }
 
+impl std::fmt::Debug for TauriEventEmitter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TauriEventEmitter").finish_non_exhaustive()
+    }
+}
+
 impl EventBus for TauriEventEmitter {
     fn emit(&self, event: &FileEvent) -> Result<(), CoreError> {
         let payload: FileEventPayload = event.into();

--- a/crates/desktop/src/state.rs
+++ b/crates/desktop/src/state.rs
@@ -48,6 +48,12 @@ pub struct AppState {
     pub search_repo: Arc<SqliteSearchRepository>,
 }
 
+impl std::fmt::Debug for AppState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppState").finish_non_exhaustive()
+    }
+}
+
 impl AppState {
     /// Construct a new `AppState` from a resolved config, metadata repo, and
     /// tag repo.
@@ -89,6 +95,12 @@ pub struct WatcherState {
     pub(crate) inner: Mutex<Option<perima_fs::DebouncedWatcher>>,
     /// Cancellation token for the background event loop, or `None` when idle.
     pub(crate) cancel: Mutex<Option<CancellationToken>>,
+}
+
+impl std::fmt::Debug for WatcherState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WatcherState").finish_non_exhaustive()
+    }
 }
 
 impl WatcherState {

--- a/crates/fs/src/watcher.rs
+++ b/crates/fs/src/watcher.rs
@@ -137,10 +137,10 @@ fn run_event_loop(
                     if cancel.is_cancelled() {
                         return;
                     }
-                    if let Some(event) = map_event(&de.event, volume_root, volume_id) {
-                        if let Err(e) = bus.emit(&event) {
-                            tracing::warn!(error = %e, "EventBus::emit failed");
-                        }
+                    if let Some(event) = map_event(&de.event, volume_root, volume_id)
+                        && let Err(e) = bus.emit(&event)
+                    {
+                        tracing::warn!(error = %e, "EventBus::emit failed");
                     }
                 }
             }

--- a/crates/fs/src/watcher.rs
+++ b/crates/fs/src/watcher.rs
@@ -30,6 +30,12 @@ pub struct DebouncedWatcher {
     >,
 }
 
+impl std::fmt::Debug for DebouncedWatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DebouncedWatcher").finish_non_exhaustive()
+    }
+}
+
 impl DebouncedWatcher {
     /// Start watching `paths` and emit [`FileEvent`]s on `bus`.
     ///

--- a/crates/media/src/extractor.rs
+++ b/crates/media/src/extractor.rs
@@ -320,6 +320,12 @@ pub struct CompositeExtractor {
     extractors: Vec<Arc<dyn MetadataExtractor>>,
 }
 
+impl std::fmt::Debug for CompositeExtractor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompositeExtractor").finish_non_exhaustive()
+    }
+}
+
 impl CompositeExtractor {
     /// Construct a composite from an explicit ordered list.
     ///

--- a/crates/media/src/extractor.rs
+++ b/crates/media/src/extractor.rs
@@ -255,12 +255,12 @@ fn video_tracks_summary(
         if matches!(track.track_type, mp4parse::TrackType::Video) {
             duration_ms = track_duration_ms(track, ctx.timescale);
 
-            if let Some(stsd) = track.stsd.as_ref() {
-                if let Some(mp4parse::SampleEntry::Video(v)) = stsd.descriptions.first() {
-                    width = Some(u32::from(v.width));
-                    height = Some(u32::from(v.height));
-                    codec = Some(format_codec(v.codec_type));
-                }
+            if let Some(stsd) = track.stsd.as_ref()
+                && let Some(mp4parse::SampleEntry::Video(v)) = stsd.descriptions.first()
+            {
+                width = Some(u32::from(v.width));
+                height = Some(u32::from(v.height));
+                codec = Some(format_codec(v.codec_type));
             }
             break;
         }

--- a/crates/media/src/queue.rs
+++ b/crates/media/src/queue.rs
@@ -53,6 +53,12 @@ pub struct MetadataQueue {
     worker: Option<JoinHandle<()>>,
 }
 
+impl std::fmt::Debug for MetadataQueue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MetadataQueue").finish_non_exhaustive()
+    }
+}
+
 impl MetadataQueue {
     /// Spawn the background worker and return a queue handle for
     /// producers.

--- a/crates/media/src/thumbnail.rs
+++ b/crates/media/src/thumbnail.rs
@@ -46,6 +46,12 @@ pub struct ThumbnailGenerator {
     enabled: bool,
 }
 
+impl std::fmt::Debug for ThumbnailGenerator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ThumbnailGenerator").finish_non_exhaustive()
+    }
+}
+
 // WHY no runtime quality parameter: the pure-Rust `image` crate
 // encodes WebP losslessly in v0.25 and ignores a quality knob. The
 // plan's q=85 target documents intent for a future `libwebp` swap;

--- a/deny.toml
+++ b/deny.toml
@@ -65,9 +65,7 @@ ignore = [
     { id = "RUSTSEC-2025-0081", reason = "unic-ucd-ident: tauri-utils transitive; no upgrade" },
     # additional unic advisories identified during initial deny.toml tuning
     { id = "RUSTSEC-2025-0098", reason = "unic-ucd-version: tauri-utils transitive; no upgrade" },
-    { id = "RUSTSEC-2025-0099", reason = "unic-char-property: tauri-utils transitive; no upgrade" },
     { id = "RUSTSEC-2025-0100", reason = "unic-ucd-ident: tauri-utils transitive; no upgrade" },
-    { id = "RUSTSEC-2025-0101", reason = "tauri-utils transitive via urlpattern; no upgrade" },
     # paste macro — unmaintained; GTK bindings transitive.
     { id = "RUSTSEC-2024-0436", reason = "paste: GTK-rs transitive; no direct dep" },
     # proc-macro-error — unmaintained; GTK bindings transitive.

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,7 @@ targets = [
 [licenses]
 # Explicit allowlist. Add more as deps require.
 allow = [
+    "AGPL-3.0-or-later",  # perima's own license (applies to workspace crates)
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",  # used by target-lexicon (Tauri transitive)
     "MIT",

--- a/justfile
+++ b/justfile
@@ -27,7 +27,7 @@ mdbook-test:
     cargo test --workspace --doc -- --show-output
 
 docs-coverage:
-    cargo doc --workspace --no-deps
+    RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
 
 fmt-check:
     cargo fmt --all -- --check

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,13 +1,15 @@
 [toolchain]
-# WHY: enforce perima's declared MSRV. Without this pin, every `cargo`
-# invocation would resolve to whatever stable is installed locally or
-# to `dtolnay/rust-toolchain@stable` in CI — allowing code to silently
-# depend on a post-MSRV API and breaking builds on machines honoring
-# the declared MSRV. Pinning here makes `rust-version` in Cargo.toml
-# enforced rather than decorative.
+# WHY channel = "stable": matches CI's `dtolnay/rust-toolchain@stable`
+# so local and CI resolve to the same rustc. A fixed MSRV pin (e.g.
+# `channel = "1.88"`) sounded appealing for reproducibility, but
+# `specta = "=2.0.0-rc.24"` (pinned transitively by tauri-specta) uses
+# `debug_closure_helpers` and const `TypeId::of` — both stabilized
+# after 1.88 — so the pre-push hook fails under a 1.88 pin when it
+# builds the desktop crate.
 #
-# Channel matches `rust-version` in the workspace Cargo.toml. Bump in
-# lockstep with any dep-requirement upgrade (e.g., if `sysinfo` needs
-# 1.90, bump both to 1.90 in the same commit).
-channel = "1.88"
+# The declared `rust-version` in Cargo.toml is the aspirational MSRV
+# floor for non-desktop crates; actual enforcement of a specific
+# version is deferred to a CI matrix job (see GH issue tracking
+# CI reproducibility).
+channel = "stable"
 components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,13 @@
+[toolchain]
+# WHY: enforce perima's declared MSRV. Without this pin, every `cargo`
+# invocation would resolve to whatever stable is installed locally or
+# to `dtolnay/rust-toolchain@stable` in CI — allowing code to silently
+# depend on a post-MSRV API and breaking builds on machines honoring
+# the declared MSRV. Pinning here makes `rust-version` in Cargo.toml
+# enforced rather than decorative.
+#
+# Channel matches `rust-version` in the workspace Cargo.toml. Bump in
+# lockstep with any dep-requirement upgrade (e.g., if `sysinfo` needs
+# 1.90, bump both to 1.90 in the same commit).
+channel = "1.88"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Hardening sweep on a long-lived feature branch: two Rust strictness waves, license switch to AGPL-3.0-or-later, MSRV alignment with actual dep requirements, ESLint + rustdoc gate tightening, and the follow-up fixes they each surfaced. 14 atomic commits, each independently revertable; full local gate (\`just ci\`) green at HEAD.

## Changes (by commit, bottom-up)

### Prereq hardening

- \`3e73070\` chore(release): sync Cargo.lock to v0.6.4 (orphaned from prior release commit)
- \`081c694\` refactor(core,db): repository traits take \`&self\` instead of \`&mut self\` — unblocks \`Arc<dyn FileRepository>\` sharing across Tauri commands and future HTTP handlers; 32 unused-mut cleanups bundled
- \`9d0d932\` chore(deny): drop stale RUSTSEC-2025-0099/0101 advisory ignores (crates no longer in graph)

### Strictness wave 1 (Rust, zero/small-scope fallout)

- \`39105b6\` chore(lints): \`clippy::dbg_macro/todo/unimplemented = deny\` + \`undocumented_unsafe_blocks = warn\`
- \`1b03afe\` chore(lints): \`missing_debug_implementations = warn\` + 9 manual \`finish_non_exhaustive()\` impls
- \`b90b036\` chore(lints): \`clippy::unwrap_used = warn\` + scoped \`#[allow(..., reason = ...)]\` on 2 test modules

### Strictness wave 2 (Rust, policy-sensitive)

- \`2b16067\` chore(lints): \`clippy::print_stdout/print_stderr = warn\` + CLI crate-root allow (\`tracing\` migration flagged for future)
- \`26f933d\` chore(lints): \`unreachable_pub = warn\` + 38 \`pub → pub(crate)\` conversions in CLI binary
- \`3f6da0b\` fix(cli): revert unneeded \`pub(crate) mod\` promotions + correct the reason string (follow-up to above)

### License + MSRV + gate tightening

- \`ca86eed\` chore(license): switch from MIT OR Apache-2.0 → AGPL-3.0-or-later (canonical upstream text committed; deny.toml updated)
- \`e3113ab\` chore(msrv): pin \`rust-toolchain.toml\` to 1.88; bump \`rust-version\` to match actual dep requirements (sysinfo, time each require 1.88+)
- \`080bf6e\` chore(gates): ESLint \`--max-warnings 0\` + \`RUSTDOCFLAGS=\"-D warnings\"\` (caught a \`Vec<T>\` HTML-tag bug in a doc comment)

### Follow-up fixes surfaced by the above

- \`e1cf823\` fix(msrv,lints): relax toolchain pin to \`stable\` (specta rc24 requires post-1.88 features); collapse 3 if-let nests that stable's clippy 1.95 flagged
- \`333c4b6\` fix(desktop): 9 clippy errors in desktop crate that only surfaced when the pre-push hook ran the full workspace gate (sandbox had no gtk deps to catch them earlier)

## Deferred / tracked separately

GitHub issues #63–#77 cover the remaining work:

- **#63** — Rust wave 3: \`clippy::allow_attributes_without_reason\` audit (51 sites), \`clippy::missing_assert_message\` re-eval
- **#64** — CI tooling wave: cargo-mutants, cargo-llvm-cov, cargo-public-api, cargo-semver-checks, cargo-machete, lychee, markdownlint-cli2, commitlint length rules
- **#65** — TS strictness: \`strict-type-checked\` full adoption, \`@vitest/eslint-plugin\` rules, tsconfig tier-2/3 flags, \`type-coverage --at-least 99\`
- **#66** — \`crates/app\` UseCase extract (Phase 6 prep)
- **#67** — write-actor + read-pool SQLite connection model (Phase 6 prep)
- **#68** — delete \`apps/desktop/src/types.ts\` mirror + typed \`CoreError\` at IPC
- **#69** — hoist duplicated \`CompositeEventBus\` / \`DbEventHandler\` / \`LogEventHandler\` (blocked on #66)
- **#70** — \`rustfmt.toml\` nightly-options silent-skip fix + missing stable flags
- **#71** — restore \`@typescript-eslint/no-explicit-any\` from warn → error
- **#72** — CI reproducibility bundle (MSRV matrix job, bun version pin, Dependabot)
- **#73** — kani workflow \`continue-on-error: true\` → conditional (once a real proof lands)
- **#74** — workspace Cargo.toml metadata completeness + frontend \`package.json\` version drift
- **#75** — migration SQL policy gate (\`deleted_at IS NULL\` on new FTS triggers)
- **#76** — CI should run on all branch pushes, not only main + pull_request
- **#77** — document + automate gtk Linux system deps for local \`just ci\`

## Test plan

- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean on the user's machine (pre-push hook verified)
- [x] \`cargo test --workspace --all-targets\` passing (pre-push hook verified)
- [x] \`cargo deny check\` passing (advisories/bans/licenses/sources all ok)
- [x] \`cargo doc --workspace --no-deps\` clean under \`RUSTDOCFLAGS=\"-D warnings\"\`
- [x] \`bun run lint --max-warnings 0\` clean
- [x] Pre-push lefthook all steps green (clippy, cargo-test, cargo-doctest, docs-coverage, cargo-deny, frontend-build, frontend-test)
- [x] CI confirms the above on the 3-OS matrix (Linux/macOS/Windows) — will run on this PR

## Merge strategy

**Create a merge commit** (or rebase-and-merge). Do **not** squash — the 14 commits are designed to be independently revertable; each commit passes \`cargo clippy -D warnings\` on its own.