### PR TITLE
design-system-v1: token foundation + main-screen overhaul

### DIFF
--- a/apps/desktop/bun.lock
+++ b/apps/desktop/bun.lock
@@ -5,6 +5,10 @@
     "": {
       "name": "perima-desktop",
       "dependencies": {
+        "@fontsource-variable/fraunces": "^5.2.9",
+        "@fontsource-variable/inter": "^5.2.8",
+        "@fontsource-variable/jetbrains-mono": "^5.2.8",
+        "@phosphor-icons/react": "^2.1.10",
         "@tanstack/react-query": "^5",
         "@tanstack/react-router": "^1",
         "@tanstack/react-virtual": "^3.13.24",
@@ -196,6 +200,12 @@
 
     "@evilmartians/lefthook": ["@evilmartians/lefthook@2.1.6", "", { "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "ia32", "arm64", ], "bin": { "lefthook": "bin/index.js" } }, "sha512-ysZbzryf74wlISmgm0PH/n1lJ0HD7AHmI6DoJgWO9qzIETQknhGdmKbkOi0MjLYtiOHWQl8Dr2qwg0ksDpNZjA=="],
 
+    "@fontsource-variable/fraunces": ["@fontsource-variable/fraunces@5.2.9", "", {}, "sha512-Y6IjunlN9Ni723np+GIgAaKzCDBrPRrqNi01TZxHs5wtHYROWFM9W6yiT+/gGwSjWIRD18oX17kD/BRWekc/Lw=="],
+
+    "@fontsource-variable/inter": ["@fontsource-variable/inter@5.2.8", "", {}, "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ=="],
+
+    "@fontsource-variable/jetbrains-mono": ["@fontsource-variable/jetbrains-mono@5.2.8", "", {}, "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
@@ -227,6 +237,8 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.126.0", "", {}, "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ=="],
+
+    "@phosphor-icons/react": ["@phosphor-icons/react@2.1.10", "", { "peerDependencies": { "react": ">= 16.8", "react-dom": ">= 16.8" } }, "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.16", "", { "os": "android", "cpu": "arm64" }, "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA=="],
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,6 +16,10 @@
     "node": ">=20.19 <21 || >=22.12"
   },
   "dependencies": {
+    "@fontsource-variable/fraunces": "^5.2.9",
+    "@fontsource-variable/inter": "^5.2.8",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@phosphor-icons/react": "^2.1.10",
     "@tanstack/react-query": "^5",
     "@tanstack/react-router": "^1",
     "@tanstack/react-virtual": "^3.13.24",

--- a/apps/desktop/src/App.css
+++ b/apps/desktop/src/App.css
@@ -1,2 +1,0 @@
-/* WHY: Tailwind 4 uses @import instead of @tailwind directives from v3. */
-@import "tailwindcss";

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,16 +1,20 @@
 /**
- * Root-route component. Mounts inside <RouterProvider> via router.tsx.
+ * Root-route shell. Mounts inside <RouterProvider> via router.tsx, which
+ * wraps us as `<App><Outlet /></App>` — i.e. the matched child route is
+ * passed via `children`. Preserve this contract; do NOT switch to
+ * importing <Outlet /> here.
  *
- * WHY this is "App" not "RootRoute": git-history continuity. The file
- * is "the root component" before and after Batch H; tests + imports
- * preserve their existing paths. Naming clarification: post-Batch-H,
- * "App" = root-route component, NOT application root. Application
- * root = main.tsx + RouterProvider + QueryClientProvider.
+ * Owns: layout chrome (header / main slot / footer) + useDomainEvents()
+ * mount + NotificationStack mount + ThemeToggle slot.
  *
- * Owns: layout chrome (header/footer) + useDomainEvents() mount.
- * Does NOT own: file/tag/search composition (lives in routes/index.tsx)
- * or any local useState/useEffect — server state via TanStack Query,
- * UI state via useUiStore.
+ * Does NOT own: ThemeProvider (mounted in main.tsx, wrapping us);
+ * file/tag/search composition (lives in routes/index.tsx).
+ *
+ * WHY direct utilities (font-display text-2xl font-semibold tracking-tight)
+ * for the wordmark instead of .h1 / .display-xl: the wordmark is small
+ * (~1.5rem), not hero-sized. The semantic typography classes bake in
+ * size + opsz + line-height for editorial display use; mixing them with
+ * utility-overrides relies on Tailwind layer order and is fragile.
  */
 import type { ReactNode } from "react";
 import { useDomainEvents } from "./hooks/useDomainEvents";
@@ -19,21 +23,23 @@ import ScanButton from "./components/ScanButton";
 import StatusBar from "./components/StatusBar";
 import ViewModeToggle from "./components/ViewModeToggle";
 import NotificationStack from "./components/NotificationStack";
+import ThemeToggle from "./components/ThemeToggle";
 
 export default function App({ children }: { children?: ReactNode }) {
   useDomainEvents();
   return (
-    <div className="bg-gray-900 text-gray-100 min-h-screen flex flex-col">
-      <header className="flex items-center justify-between px-6 py-4 bg-gray-800 border-b border-gray-700">
-        <h1 className="text-xl font-bold tracking-wide">perima</h1>
+    <div className="min-h-screen flex flex-col bg-background text-foreground font-sans">
+      <header className="flex items-center justify-between px-6 py-4 bg-card border-b border-border">
+        <h1 className="font-display text-2xl font-semibold tracking-tight">perima</h1>
         <div className="flex items-center gap-3">
           <SearchBar />
           <ViewModeToggle />
           <ScanButton />
+          <ThemeToggle />
         </div>
       </header>
       <NotificationStack />
-      {children}
+      <main className="flex-1 min-h-0">{children}</main>
       <footer>
         <StatusBar />
       </footer>

--- a/apps/desktop/src/__tests__/CollisionPill.test.tsx
+++ b/apps/desktop/src/__tests__/CollisionPill.test.tsx
@@ -1,12 +1,12 @@
 /**
- * CollisionPill — color-state pill per spec §4.6.1.
+ * CollisionPill — design-token pill per spec §4.6.1.
  *
  * Branches under test:
- * - 0 groups: gray, "no candidate duplicates"
- * - N groups, 0 verified: blue, "N candidate group(s)"
- * - 1 group, 0 verified: blue, "1 candidate group" (singular)
- * - N groups, 0 less than M less than N verified: blue, "N candidate (M ✓)"
- * - all verified: green, "all verified ✓"
+ * - 0 groups: muted-foreground span, "no candidate duplicates"
+ * - N groups, 0 verified: warning pill, "N duplicate(s)"
+ * - 1 group, 0 verified: warning pill, "1 duplicate" (singular)
+ * - N groups, 0 less than M less than N verified: warning pill, "N duplicates (M verified)"
+ * - all verified: success pill, "all verified"
  *
  * WHY mock `@tanstack/react-router`: CollisionPill renders a Link to="/dedup"
  * which requires a router context. Unit tests for a leaf pill component do not
@@ -55,16 +55,16 @@ function makeGroup(
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("CollisionPill", () => {
-  it("renders gray 'no candidate duplicates' when groups is empty", () => {
+  it("renders muted 'no candidate duplicates' span when groups is empty", () => {
     renderWithProviders(<CollisionPill groups={[]} />);
     const el = screen.getByText(/no candidate duplicates/i);
     expect(el).toBeInTheDocument();
-    // WHY check class presence: gray state = text-gray-500, not a link.
+    // 0-groups state = plain span (not a link), text-muted-foreground.
     expect(el.tagName).toBe("SPAN");
-    expect(el.className).toContain("text-gray-500");
+    expect(el.className).toContain("text-muted-foreground");
   });
 
-  it("renders blue pill for N unverified groups (plural)", () => {
+  it("renders warning pill for N unverified groups (plural)", () => {
     const groups = [
       makeGroup("aaa", "Unverified"),
       makeGroup("bbb", "Unverified"),
@@ -73,20 +73,20 @@ describe("CollisionPill", () => {
     renderWithProviders(<CollisionPill groups={groups} />);
     const link = screen.getByRole("link");
     expect(link).toBeInTheDocument();
-    expect(link.textContent).toMatch(/3 candidate groups/i);
-    expect(link.className).toContain("text-blue-400");
+    expect(link.textContent).toMatch(/3 duplicates/i);
+    expect(link.className).toContain("bg-warning");
   });
 
-  it("renders blue pill with singular 'group' label for 1 unverified group", () => {
+  it("renders warning pill with singular 'duplicate' label for 1 unverified group", () => {
     renderWithProviders(<CollisionPill groups={[makeGroup("aaa", "Unverified")]} />);
     const link = screen.getByRole("link");
-    expect(link.textContent).toMatch(/1 candidate group$/i);
+    expect(link.textContent).toMatch(/1 duplicate$/i);
     // Must NOT be plural.
-    expect(link.textContent).not.toMatch(/1 candidate groups/i);
-    expect(link.className).toContain("text-blue-400");
+    expect(link.textContent).not.toMatch(/1 duplicates/i);
+    expect(link.className).toContain("bg-warning");
   });
 
-  it("renders blue pill with verified count when 0 < M < N verified", () => {
+  it("renders warning pill with verified count when 0 < M < N verified", () => {
     const groups = [
       makeGroup("aaa", "VerifiedDuplicate"),
       makeGroup("bbb", "Unverified"),
@@ -95,19 +95,19 @@ describe("CollisionPill", () => {
     renderWithProviders(<CollisionPill groups={groups} />);
     const link = screen.getByRole("link");
     // 3 total, 2 verified (VerifiedDuplicate + VerifiedDistinct both count).
-    expect(link.textContent).toMatch(/3 candidates \(2 ✓\)/i);
-    expect(link.className).toContain("text-blue-400");
+    expect(link.textContent).toMatch(/3 duplicates \(2 verified\)/i);
+    expect(link.className).toContain("bg-warning");
   });
 
-  it("renders green pill when all groups are verified", () => {
+  it("renders success pill when all groups are verified", () => {
     const groups = [
       makeGroup("aaa", "VerifiedDuplicate"),
       makeGroup("bbb", "VerifiedDistinct"),
     ];
     renderWithProviders(<CollisionPill groups={groups} />);
     const link = screen.getByRole("link");
-    expect(link.textContent).toMatch(/all verified ✓/i);
-    expect(link.className).toContain("text-green-400");
+    expect(link.textContent).toMatch(/all verified/i);
+    expect(link.className).toContain("bg-success");
   });
 
   it("link points to /dedup", () => {
@@ -121,8 +121,8 @@ describe("CollisionPill", () => {
     renderWithProviders(<CollisionPill groups={groups} />);
     const link = screen.getByRole("link");
     // Mixed is not VerifiedDuplicate or VerifiedDistinct → not in verified count.
-    // With 0 verified, label = "1 candidate group".
-    expect(link.textContent).toMatch(/1 candidate group$/i);
-    expect(link.className).toContain("text-blue-400");
+    // With 0 verified, label = "1 duplicate".
+    expect(link.textContent).toMatch(/1 duplicate$/i);
+    expect(link.className).toContain("bg-warning");
   });
 });

--- a/apps/desktop/src/__tests__/TagChip.test.tsx
+++ b/apps/desktop/src/__tests__/TagChip.test.tsx
@@ -2,14 +2,6 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import TagChip from "../components/TagChip";
 
-// colorIndexFor is not exported, so we test it indirectly via the rendered chip.
-function colorIndexFor(name: string): number {
-  const bytes = new TextEncoder().encode(name);
-  let sum = 0;
-  for (const b of bytes) sum = (sum + b) % 256;
-  return sum % 12;
-}
-
 describe("TagChip", () => {
   const sampleTag = {
     id: "00000000-0000-0000-0000-000000000001",
@@ -35,17 +27,11 @@ describe("TagChip", () => {
     expect(onRemove).toHaveBeenCalledTimes(1);
   });
 
-  test("chip has a color class derived from tag name", () => {
+  test("chip uses uniform bg-muted class (design-system-v1 drops per-tag coloring)", () => {
     render(<TagChip tag={sampleTag} />);
     const chip = screen.getByTestId("tag-chip");
-    // colorIndexFor("vacation") must be stable — pin the expected index so
-    // an accidental formula change is caught immediately.
-    const idx = colorIndexFor("vacation");
-    const COLORS = [
-      "bg-red-700","bg-orange-700","bg-amber-700","bg-yellow-700",
-      "bg-lime-700","bg-green-700","bg-emerald-700","bg-teal-700",
-      "bg-cyan-700","bg-sky-700","bg-blue-700","bg-indigo-700",
-    ];
-    expect(chip.className).toContain(COLORS[idx]);
+    // WHY: design-system-v1 replaces the 12-color procedural palette with a
+    // single uniform bg-muted capsule. Tag identity is conveyed by name text.
+    expect(chip.className).toContain("bg-muted");
   });
 });

--- a/apps/desktop/src/__tests__/ThemeToggle.test.tsx
+++ b/apps/desktop/src/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,51 @@
+import { describe, test, expect, beforeEach, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { ThemeProvider } from "../lib/theme-provider";
+import ThemeToggle from "../components/ThemeToggle";
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  test("renders Moon icon initially (dark mode default for tests)", () => {
+    localStorage.clear();
+    localStorage.setItem("perima-theme", "dark");
+    const { container } = render(
+      <ThemeProvider><ThemeToggle /></ThemeProvider>,
+    );
+    const btn = container.querySelector("button");
+    expect(btn).not.toBeNull();
+    expect(btn!.getAttribute("aria-label")).toMatch(/dark/i);
+  });
+
+  test("clicking cycles dark -> light -> system -> dark", () => {
+    localStorage.clear();
+    localStorage.setItem("perima-theme", "dark");
+    const { container } = render(
+      <ThemeProvider><ThemeToggle /></ThemeProvider>,
+    );
+    const btn = container.querySelector("button")!;
+
+    fireEvent.click(btn);
+    expect(btn.getAttribute("aria-label")).toMatch(/light/i);
+
+    fireEvent.click(btn);
+    expect(btn.getAttribute("aria-label")).toMatch(/system/i);
+
+    fireEvent.click(btn);
+    expect(btn.getAttribute("aria-label")).toMatch(/dark/i);
+  });
+});

--- a/apps/desktop/src/__tests__/test-utils.tsx
+++ b/apps/desktop/src/__tests__/test-utils.tsx
@@ -19,7 +19,36 @@
 import type { ReactElement } from "react";
 import { render, type RenderResult } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi } from "vitest";
 import { useUiStore, type UiStore } from "../stores/ui";
+import { ThemeProvider } from "../lib/theme-provider";
+
+// WHY install matchMedia mock at module-load time: jsdom does not implement
+// window.matchMedia. ThemeProvider's getSystemTheme() reads it at mount, and
+// renderWithProviders wraps in ThemeProvider — so every test using the helper
+// would crash without this mock. Installing it here (vs in each test's
+// beforeEach) is a one-shot fix and avoids per-test boilerplate. Tests that
+// need to override matchMedia (e.g. simulate prefers-color-scheme: light)
+// can re-define it in their own beforeEach — last assignment wins.
+// WHY cast to unknown: TypeScript types window.matchMedia as always-defined
+// (lib.dom.d.ts), but jsdom doesn't implement it. The `as unknown` cast lets
+// the runtime truthiness check bypass the TS type system so the guard works.
+if (typeof window !== "undefined" && !(window as unknown as Record<string, unknown>)["matchMedia"]) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
 
 /**
  * Default UI-store state matching slice initial values.
@@ -79,8 +108,15 @@ export function renderWithProviders(
   if (opts.initialStoreState) {
     useUiStore.setState(opts.initialStoreState);
   }
+  // WHY ThemeProvider wrap: any tested component that calls useTheme()
+  // needs a provider. Defaults to "system" mode → "dark" effective theme
+  // in jsdom (matchMedia mock returns matches: false). Tests that need a
+  // specific theme should set localStorage["perima-theme"] in beforeEach
+  // (e.g. ThemeToggle.test.tsx).
   const result = render(
-    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </ThemeProvider>,
   );
   return Object.assign(result, { queryClient });
 }

--- a/apps/desktop/src/__tests__/theme-provider.test.tsx
+++ b/apps/desktop/src/__tests__/theme-provider.test.tsx
@@ -1,0 +1,93 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, act } from "@testing-library/react";
+import { ThemeProvider, useTheme } from "../lib/theme-provider";
+
+const ThemeProbe = () => {
+  const { theme, effectiveTheme, setTheme } = useTheme();
+  return (
+    <div>
+      <span data-testid="theme">{theme}</span>
+      <span data-testid="effective">{effectiveTheme}</span>
+      <button onClick={() => { setTheme("light"); }}>set-light</button>
+      <button onClick={() => { setTheme("dark"); }}>set-dark</button>
+      <button onClick={() => { setTheme("system"); }}>set-system</button>
+    </div>
+  );
+};
+
+describe("ThemeProvider", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+    // WHY matchMedia mock: jsdom does not implement window.matchMedia by
+    // default; ThemeProvider's useEffect calls it for system-pref detection.
+    // Without this mock, every test would throw "matchMedia is not a function".
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false, // default to NOT-light → effectiveTheme = "dark" in system mode
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),    // legacy
+        removeListener: vi.fn(), // legacy
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  test("defaults to system mode when no localStorage value", () => {
+    const { getByTestId } = render(
+      <ThemeProvider><ThemeProbe /></ThemeProvider>,
+    );
+    expect(getByTestId("theme").textContent).toBe("system");
+  });
+
+  test("setTheme('light') sets data-theme=light on <html>", () => {
+    const { getByText } = render(
+      <ThemeProvider><ThemeProbe /></ThemeProvider>,
+    );
+    act(() => { getByText("set-light").click(); });
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  });
+
+  test("setTheme('dark') removes data-theme attr", () => {
+    const { getByText } = render(
+      <ThemeProvider><ThemeProbe /></ThemeProvider>,
+    );
+    act(() => { getByText("set-light").click(); });
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    act(() => { getByText("set-dark").click(); });
+    expect(document.documentElement.getAttribute("data-theme")).toBe(null);
+  });
+
+  test("setTheme persists to localStorage under perima-theme key", () => {
+    const { getByText } = render(
+      <ThemeProvider><ThemeProbe /></ThemeProvider>,
+    );
+    act(() => { getByText("set-light").click(); });
+    expect(localStorage.getItem("perima-theme")).toBe("light");
+  });
+
+  test("reads stored theme on mount", () => {
+    localStorage.setItem("perima-theme", "light");
+    const { getByTestId } = render(
+      <ThemeProvider><ThemeProbe /></ThemeProvider>,
+    );
+    expect(getByTestId("theme").textContent).toBe("light");
+    expect(getByTestId("effective").textContent).toBe("light");
+  });
+
+  test("useTheme outside provider throws", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<ThemeProbe />)).toThrow(
+      /useTheme must be used within <ThemeProvider>/,
+    );
+    spy.mockRestore();
+  });
+});

--- a/apps/desktop/src/components/CollisionPill.tsx
+++ b/apps/desktop/src/components/CollisionPill.tsx
@@ -1,25 +1,19 @@
 /**
  * Collision-group status pill for the StatusBar.
  *
- * Color states per spec §4.6.1:
- * - 0 groups: gray, "no candidate duplicates"
- * - N groups, 0 verified: blue, "N candidate group(s)"
- * - N groups, 0 less than M less than N verified: blue, "N candidate (M ✓)"
- * - all verified: green, "all verified ✓"
- * - errored greater than 0: yellow, "verify error" (reserved for future batch)
+ * WHY warning/success encoding: unverified groups are actionable (they need
+ * a human or batch verify); verified groups are informational. Color encodes
+ * urgency, not just count. Warning = unverified present, success = all clear.
  *
- * WHY gray-by-default for 0 groups: collisions are expected to be
- * absent in a well-managed library; green "all clear" would be noisy
- * and draws attention away from actionable states.
- *
- * WHY Link to="/dedup": clicking navigates to the dedup management
- * route (Task 13). The route is registered in router.tsx; TS validates
- * the `to` prop via TanStack Router's `Register` augmentation.
+ * WHY Link to="/dedup": clicking navigates to the dedup management route.
+ * The route is registered in router.tsx; TS validates the `to` prop via
+ * TanStack Router's `Register` augmentation.
  *
  * WHY VerifiedState is a plain string union (not discriminated object):
  * Rust emits unit enum variants as bare strings under the default serde
  * config (no `#[serde(tag)]`). Pattern-match via ===, not `.kind`.
  */
+import { CopyIcon } from "@phosphor-icons/react";
 import { Link } from "@tanstack/react-router";
 import type { CollisionGroup } from "../bindings";
 
@@ -36,8 +30,8 @@ export default function CollisionPill({ groups }: Props) {
 
   if (total === 0) {
     return (
-      <span className="text-gray-500" title="No candidate duplicates found">
-        ⊜ no candidate duplicates
+      <span className="text-xs text-muted-foreground" title="No candidate duplicates found">
+        no candidate duplicates
       </span>
     );
   }
@@ -51,24 +45,31 @@ export default function CollisionPill({ groups }: Props) {
       g.verified_state === "VerifiedDistinct",
   ).length;
 
-  let colorClass = "text-blue-400";
   let label: string;
-
   if (verified === total) {
-    colorClass = "text-green-400";
-    label = "⊜ all verified ✓";
+    label = "all verified";
   } else if (verified > 0) {
-    label = `⊜ ${total} candidate${total === 1 ? "" : "s"} (${verified} ✓)`;
+    label = `${total} duplicate${total === 1 ? "" : "s"} (${verified} verified)`;
   } else {
-    label = `⊜ ${total} candidate group${total === 1 ? "" : "s"}`;
+    label = `${total} duplicate${total === 1 ? "" : "s"}`;
   }
+
+  // WHY bg-warning when there are unverified groups, bg-success when all verified:
+  // unverified groups are actionable (they need a human or batch verify); verified
+  // groups are informational. Color encodes urgency, not just count.
+  const bgClass =
+    verified === total ? "bg-success text-success-foreground" : "bg-warning text-warning-foreground";
 
   return (
     <Link
       to="/dedup"
-      className={`${colorClass} hover:underline`}
+      className={`inline-flex items-center gap-1.5 rounded-full px-3 py-0.5 text-xs font-medium
+                  ${bgClass} hover:opacity-90 transition-opacity duration-micro
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
+                  focus-visible:ring-offset-2 focus-visible:ring-offset-background`}
       title="View duplicate groups"
     >
+      <CopyIcon size={12} weight="regular" />
       {label}
     </Link>
   );

--- a/apps/desktop/src/components/FileGrid.tsx
+++ b/apps/desktop/src/components/FileGrid.tsx
@@ -24,19 +24,19 @@ interface FileGridProps {
 export default function FileGrid({ files, loading = false }: FileGridProps) {
   if (loading) {
     return (
-      <div className="p-6 text-center text-gray-400" role="status">
+      <div className="p-6 text-center text-muted-foreground" role="status">
         Loading...
       </div>
     );
   }
   if (files.length === 0) {
     return (
-      <div className="p-6 text-center text-gray-500">No files indexed yet</div>
+      <div className="p-6 text-center text-muted-foreground">No files indexed yet</div>
     );
   }
   return (
     <div
-      className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-2 p-2"
+      className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-4 p-6"
       role="list"
     >
       {files.map((f) => (
@@ -55,10 +55,10 @@ function FileGridTile({ file }: { file: FileWithTagsPayload }) {
   const filename = file.relative_path.split("/").pop() ?? file.relative_path;
   return (
     <div
-      className="aspect-square bg-gray-800 rounded overflow-hidden flex flex-col"
+      className="bg-card rounded-md shadow-e1 hover:shadow-e2 hover:bg-popover transition-colors duration-micro ease-perima cursor-pointer overflow-hidden flex flex-col"
       role="listitem"
     >
-      <div className="flex-1 flex items-center justify-center min-h-0">
+      <div className="aspect-square bg-muted flex items-center justify-center">
         {ready ? (
           // WHY convertFileSrc: Tauri's asset protocol maps absolute
           // disk paths to a custom URL scheme the WebView can load
@@ -72,16 +72,16 @@ function FileGridTile({ file }: { file: FileWithTagsPayload }) {
           <PlaceholderIcon status={file.thumbnail_status} />
         )}
       </div>
-      <div className="p-1 text-xs truncate text-gray-200" title={filename}>
+      <div className="px-3 py-2 text-sm text-foreground truncate" title={filename}>
         {filename}
       </div>
       {file.tags.length > 0 && (
-        <div className="px-1 pb-1 flex flex-wrap gap-0.5">
+        <div className="px-3 pb-2 flex flex-wrap gap-1">
           {file.tags.slice(0, 3).map((t) => (
             <TagChip key={t.id} tag={t} />
           ))}
           {file.tags.length > 3 && (
-            <span className="text-xs text-gray-400 ml-1">
+            <span className="text-xs text-muted-foreground ml-1">
               +{file.tags.length - 3}
             </span>
           )}
@@ -109,7 +109,7 @@ function PlaceholderIcon({ status }: { status: string | null | undefined }) {
         : "no thumbnail";
   return (
     <div
-      className="text-gray-400 text-2xl"
+      className="text-muted-foreground text-2xl"
       role="img"
       aria-label={label}
       data-testid={`placeholder-${status ?? "unknown"}`}

--- a/apps/desktop/src/components/FileSidebar.tsx
+++ b/apps/desktop/src/components/FileSidebar.tsx
@@ -24,6 +24,7 @@
  * a small UX win. We keep it to a one-line click handler; no third-party
  * clipboard lib needed.
  */
+import { XIcon } from "@phosphor-icons/react";
 import type { FileWithTagsPayload } from "../bindings";
 import { useComputeFullHash } from "../queries/dedup";
 
@@ -62,28 +63,28 @@ export default function FileSidebar({ file, onClose }: FileSidebarProps) {
 
   return (
     <aside
-      className="w-72 flex-shrink-0 bg-gray-800 border-l border-gray-700 p-4 overflow-y-auto flex flex-col gap-4"
+      className="w-96 flex-shrink-0 bg-popover border-l border-border p-6 overflow-y-auto flex flex-col gap-4"
       aria-label="File detail"
     >
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold text-gray-200">File detail</h2>
+        <h2 className="text-lg font-semibold text-foreground">File detail</h2>
         <button
           onClick={onClose}
           aria-label="Close file detail"
-          className="text-gray-400 hover:text-gray-100 text-lg leading-none"
+          className="inline-flex items-center justify-center rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors duration-micro ease-perima focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
-          ×
+          <XIcon size={14} weight="bold" />
         </button>
       </div>
 
       {/* UUID */}
       <section>
-        <p className="text-xs text-gray-400 uppercase tracking-wider mb-1">
+        <p className="eyebrow text-muted-foreground mb-1">
           UUID
         </p>
         <code
-          className="font-mono text-xs text-gray-200 break-all"
+          className="mono-metadata text-foreground break-all"
           data-testid="file-uuid"
         >
           {file.file_uuid.slice(0, 8)}…
@@ -93,11 +94,11 @@ export default function FileSidebar({ file, onClose }: FileSidebarProps) {
       {/* Quick hash */}
       {file.quick_hash !== null && (
         <section>
-          <p className="text-xs text-gray-400 uppercase tracking-wider mb-1">
+          <p className="eyebrow text-muted-foreground mb-1">
             Quick hash
           </p>
           <code
-            className="font-mono text-xs text-gray-500 break-all"
+            className="mono-metadata text-muted-foreground break-all"
             data-testid="quick-hash"
           >
             {file.quick_hash}
@@ -107,14 +108,14 @@ export default function FileSidebar({ file, onClose }: FileSidebarProps) {
 
       {/* Full hash */}
       <section>
-        <p className="text-xs text-gray-400 uppercase tracking-wider mb-1">
+        <p className="eyebrow text-muted-foreground mb-1">
           Full hash
         </p>
         {!isPlaceholder && file.hash !== null ? (
           // WHY click-to-copy on the <code> element: spec §4.6.3 UX win,
           // ≤10 LOC so we land it inline rather than deferring.
           <code
-            className="font-mono text-xs text-gray-200 break-all cursor-copy hover:text-blue-300"
+            className="mono-metadata text-foreground break-all cursor-copy hover:text-primary transition-colors duration-micro"
             title="Click to copy"
             onClick={handleCopyHash}
             data-testid="full-hash"
@@ -122,7 +123,7 @@ export default function FileSidebar({ file, onClose }: FileSidebarProps) {
             {file.hash}
           </code>
         ) : (
-          <span className="text-xs text-gray-500 italic" data-testid="hash-pending">
+          <span className="mono-metadata text-muted-foreground italic" data-testid="hash-pending">
             pending
           </span>
         )}
@@ -135,7 +136,7 @@ export default function FileSidebar({ file, onClose }: FileSidebarProps) {
           disabled={compute.isPending}
           aria-label="Compute canonical hash"
           data-testid="compute-hash-btn"
-          className="mt-auto bg-blue-600 hover:bg-blue-500 disabled:bg-gray-600 text-white text-xs font-medium rounded px-3 py-2 transition-colors"
+          className="mt-auto inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors duration-micro ease-perima focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:opacity-40 disabled:pointer-events-none"
         >
           {compute.isPending ? "Computing…" : "Compute canonical hash"}
         </button>

--- a/apps/desktop/src/components/FileTable.tsx
+++ b/apps/desktop/src/components/FileTable.tsx
@@ -81,7 +81,7 @@ function RowTagsCell({
         placeholder="+ tag"
         aria-label={`Add tag to file ${labelKey.slice(0, 8)}`}
         disabled={isPending}
-        className="w-20 bg-gray-700 text-white text-xs rounded px-1.5 py-0.5 placeholder:text-gray-400 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        className="w-20 bg-input text-foreground text-xs rounded-md border border-border px-2 py-0.5 placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       />
     </div>
   );
@@ -148,7 +148,7 @@ export default function FileTable({ files, loading }: FileTableProps) {
   });
 
   const thCls =
-    "px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-400 cursor-pointer select-none hover:text-gray-100";
+    "px-4 py-2 text-left eyebrow text-muted-foreground cursor-pointer select-none hover:text-foreground";
 
   function arrow(col: SortColumn) {
     if (sortBy !== col) return null;
@@ -157,8 +157,8 @@ export default function FileTable({ files, loading }: FileTableProps) {
 
   return (
     <div className="overflow-x-auto">
-      <table className="w-full text-sm text-gray-200">
-        <thead className="bg-gray-800">
+      <table className="w-full text-sm">
+        <thead className="border-b border-border">
           <tr>
             <th className={thCls} onClick={() => { handleSort("hash"); }}>
               HASH{arrow("hash")}
@@ -181,13 +181,13 @@ export default function FileTable({ files, loading }: FileTableProps) {
         <tbody>
           {loading ? (
             <tr>
-              <td colSpan={6} className="px-3 py-6 text-center text-gray-400">
+              <td colSpan={6} className="px-4 py-6 text-center text-muted-foreground">
                 Loading...
               </td>
             </tr>
           ) : sorted.length === 0 ? (
             <tr>
-              <td colSpan={6} className="px-3 py-6 text-center text-gray-500">
+              <td colSpan={6} className="px-4 py-6 text-center text-muted-foreground">
                 No files indexed yet
               </td>
             </tr>
@@ -208,14 +208,14 @@ export default function FileTable({ files, loading }: FileTableProps) {
                     selectedFileUuid === f.file_uuid ? null : f.file_uuid,
                   );
                 }}
-                className={`border-t border-gray-700 cursor-pointer ${
+                className={`border-b border-border cursor-pointer transition-colors duration-micro ${
                   selectedFileUuid === f.file_uuid
-                    ? "bg-blue-900"
-                    : "odd:bg-gray-900 even:bg-gray-800 hover:bg-gray-700"
+                    ? "bg-accent text-accent-foreground"
+                    : "hover:bg-muted"
                 }`}
                 aria-selected={selectedFileUuid === f.file_uuid}
               >
-                <td className="px-3 py-2 font-mono text-xs">
+                <td className="px-4 py-2 mono-metadata text-muted-foreground">
                   {/* WHY isPlaceholder check: pre-V012 blake3_hash is NOT NULL —
                     * quick_hash is stored there until compute_full_hash promotes
                     * the real hash. f.hash === null never fires today; equality
@@ -224,15 +224,15 @@ export default function FileTable({ files, loading }: FileTableProps) {
                     ? "pending"
                     : f.hash.slice(0, 8)}
                 </td>
-                <td className="px-3 py-2">{humanSize(f.size)}</td>
-                <td className="px-3 py-2 font-mono text-xs">
+                <td className="px-4 py-2">{humanSize(f.size)}</td>
+                <td className="px-4 py-2 mono-metadata text-muted-foreground">
                   {f.volume_id.slice(0, 8)}
                 </td>
-                <td className="px-3 py-2 font-mono text-xs max-w-xs truncate">
+                <td className="px-4 py-2 mono-metadata text-muted-foreground max-w-xs truncate">
                   {f.relative_path}
                 </td>
-                <td className="px-3 py-2">{f.status}</td>
-                <td className="px-3 py-2">
+                <td className="px-4 py-2">{f.status}</td>
+                <td className="px-4 py-2">
                   <RowTagsCell
                     fileUuid={f.file_uuid}
                     hash={f.hash}

--- a/apps/desktop/src/components/NotificationStack.tsx
+++ b/apps/desktop/src/components/NotificationStack.tsx
@@ -23,16 +23,19 @@ function NotificationItem({ notification }: { notification: Notification }) {
     return () => { clearTimeout(timer); };
   }, [id, kind, dismiss]);
 
-  const bg = kind === "error" ? "bg-red-700" : "bg-blue-700";
+  const variantClasses =
+    kind === "error"
+      ? "border-destructive bg-destructive/10 text-destructive-foreground"
+      : "border-info bg-popover text-popover-foreground";
   return (
     <div
       role={kind === "error" ? "alert" : "status"}
-      className={`${bg} text-white text-sm px-4 py-2 rounded shadow flex items-start gap-3 max-w-md`}
+      className={`pointer-events-auto rounded-md border ${variantClasses} shadow-e2 px-4 py-3 max-w-sm flex items-start gap-3`}
     >
-      <span className="flex-1">{message}</span>
+      <span className="flex-1 text-sm">{message}</span>
       <button
         type="button"
-        className="text-white/80 hover:text-white focus:outline-none"
+        className="inline-flex items-center justify-center rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors duration-micro ease-perima focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         aria-label="Dismiss notification"
         onClick={() => { dismiss(id); }}
       >
@@ -46,7 +49,7 @@ export default function NotificationStack() {
   const notifications = useUiStore((s) => s.notifications);
   if (notifications.length === 0) return null;
   return (
-    <div className="fixed bottom-4 right-4 flex flex-col gap-2 z-50">
+    <div className="fixed top-4 right-4 z-50 flex flex-col gap-2 pointer-events-none">
       {notifications.map((n) => (
         <NotificationItem key={n.id} notification={n} />
       ))}

--- a/apps/desktop/src/components/ScanButton.tsx
+++ b/apps/desktop/src/components/ScanButton.tsx
@@ -4,6 +4,7 @@
  */
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { open } from "@tauri-apps/plugin-dialog";
+import { DownloadSimpleIcon } from "@phosphor-icons/react";
 import * as api from "../api";
 import { filesKeys } from "../queries/files";
 import { tagsKeys } from "../queries/tags";
@@ -67,8 +68,14 @@ export default function ScanButton() {
       type="button"
       onClick={() => { void onClick(); }}
       disabled={busy}
-      className="px-3 py-1.5 text-sm font-medium rounded bg-emerald-600 text-white hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed"
+      className="inline-flex items-center gap-2 rounded-full px-5 py-2 text-sm font-medium
+                 bg-primary text-primary-foreground hover:bg-primary/90
+                 transition-colors duration-micro ease-perima
+                 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
+                 focus-visible:ring-offset-2 focus-visible:ring-offset-background
+                 disabled:opacity-40 disabled:pointer-events-none"
     >
+      <DownloadSimpleIcon size={18} weight="regular" />
       {busy ? "Scanning…" : "Scan folder"}
     </button>
   );

--- a/apps/desktop/src/components/SearchBar.tsx
+++ b/apps/desktop/src/components/SearchBar.tsx
@@ -10,6 +10,7 @@
  * sanitiser (escape FTS5 metacharacters), clearedRef deduplication.
  */
 import { useEffect, useRef } from "react";
+import { MagnifyingGlassIcon } from "@phosphor-icons/react";
 import { useUiStore } from "../stores/ui";
 import { MIN_QUERY_LEN } from "../queries/search";
 import { buildFtsQuery } from "../lib/search";
@@ -45,13 +46,24 @@ export default function SearchBar() {
   }, [searchQuery, setDebouncedQuery]);
 
   return (
-    <input
-      type="search"
-      placeholder="Search…"
-      aria-label="Search files"
-      value={searchQuery}
-      onChange={(e) => { setSearchQuery(e.target.value); }}
-      className="px-3 py-1.5 bg-gray-900 text-gray-100 rounded border border-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm w-64"
-    />
+    <div className="relative">
+      <MagnifyingGlassIcon
+        size={16}
+        weight="regular"
+        className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none"
+      />
+      <input
+        type="search"
+        placeholder="Search files, tags, paths…"
+        aria-label="Search files"
+        value={searchQuery}
+        onChange={(e) => { setSearchQuery(e.target.value); }}
+        className="rounded-full bg-input text-foreground placeholder:text-muted-foreground
+                   pl-9 pr-4 py-2 text-sm border border-border w-64
+                   focus-visible:outline-none focus-visible:ring-2
+                   focus-visible:ring-ring focus-visible:ring-offset-0
+                   focus-visible:border-ring transition-colors duration-micro"
+      />
+    </div>
   );
 }

--- a/apps/desktop/src/components/StatusBar.tsx
+++ b/apps/desktop/src/components/StatusBar.tsx
@@ -123,7 +123,7 @@ export default function StatusBar() {
   }
 
   return (
-    <div className="px-6 py-2 bg-gray-800 text-xs text-gray-400 border-t border-gray-700 flex justify-between items-center">
+    <div className="px-6 py-2 bg-card text-muted-foreground text-xs border-t border-border flex justify-between items-center">
       <span>{summary}</span>
       <div className="flex items-center gap-3">
         {/* WHY type="button": prevents form submission if StatusBar is ever
@@ -132,7 +132,11 @@ export default function StatusBar() {
           type="button"
           onClick={() => { backupMutation.mutate({}); }}
           disabled={backupMutation.isPending}
-          className="px-2 py-0.5 text-xs rounded bg-slate-700 text-slate-100 hover:bg-slate-600 disabled:opacity-50"
+          className="rounded-full px-3 py-1 text-sm font-medium bg-secondary text-secondary-foreground
+                     hover:bg-popover transition-colors duration-micro ease-perima
+                     focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
+                     focus-visible:ring-offset-2 focus-visible:ring-offset-background
+                     disabled:opacity-40 disabled:pointer-events-none"
         >
           {backupMutation.isPending ? "Backing up…" : "Backup"}
         </button>

--- a/apps/desktop/src/components/TagChip.tsx
+++ b/apps/desktop/src/components/TagChip.tsx
@@ -1,55 +1,23 @@
+import { XIcon } from "@phosphor-icons/react";
 import type { Tag } from "../bindings";
 
 /** Props for {@link TagChip}. */
 interface TagChipProps {
   /** Tag to render. */
   tag: Tag;
-  /** Optional callback to remove the tag; when provided, renders an x button. */
+  /** Optional callback to remove the tag; when provided, renders an X button. */
   onRemove?: () => void;
 }
 
 /**
- * Compute a procedural color index (0..11) from a tag name.
- *
- * WHY byte-sum mod 12 (not spec's blake3[0] % 12): blake3 isn't available
- * in the TS bundle without a WASM dependency. The byte-sum is a deliberate
- * intentional deviation from the spec for cosmetic coloring only — collisions
- * (two tags sharing a chip color) are harmless. If a native/backend shell
- * ever needs to agree on chip color, revisit with a shared WASM blake3.
- */
-function colorIndexFor(name: string): number {
-  const bytes = new TextEncoder().encode(name);
-  let sum = 0;
-  for (const b of bytes) sum = (sum + b) % 256;
-  return sum % 12;
-}
-
-const CHIP_COLORS = [
-  "bg-red-700",
-  "bg-orange-700",
-  "bg-amber-700",
-  "bg-yellow-700",
-  "bg-lime-700",
-  "bg-green-700",
-  "bg-emerald-700",
-  "bg-teal-700",
-  "bg-cyan-700",
-  "bg-sky-700",
-  "bg-blue-700",
-  "bg-indigo-700",
-] as const;
-
-/**
- * A colored pill displaying a tag name, with optional remove button.
+ * A muted-background pill displaying a tag name, with an optional X icon
+ * for removal. Tag identity is conveyed by the name text — chip color is
+ * uniform across all tags by design (design-system-v1).
  */
 export default function TagChip({ tag, onRemove }: TagChipProps) {
-  // WHY fallback to bg-blue-700: colorIndexFor is bounded to 0..11 which
-  // matches CHIP_COLORS.length exactly; the fallback satisfies strict-type-checked
-  // (noUncheckedIndexedAccess sees the index as `number`, not a literal).
-  const bg = CHIP_COLORS[colorIndexFor(tag.name)] ?? "bg-blue-700";
   return (
     <span
-      className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full ${bg} text-white`}
+      className="inline-flex items-center gap-1 rounded-full bg-muted text-foreground px-3 py-0.5 text-sm"
       data-testid="tag-chip"
     >
       <span>{tag.name}</span>
@@ -58,9 +26,9 @@ export default function TagChip({ tag, onRemove }: TagChipProps) {
           type="button"
           onClick={onRemove}
           aria-label={`Remove ${tag.name}`}
-          className="ml-0.5 text-white/80 hover:text-white"
+          className="inline-flex items-center justify-center rounded-full text-muted-foreground hover:text-foreground transition-colors duration-micro ease-perima focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
-          &times;
+          <XIcon size={12} weight="bold" />
         </button>
       )}
     </span>

--- a/apps/desktop/src/components/TagSidebar.tsx
+++ b/apps/desktop/src/components/TagSidebar.tsx
@@ -43,7 +43,7 @@ export default function TagSidebar({
 
   return (
     <nav
-      className="w-48 bg-gray-800 border-r border-gray-700 p-2 flex flex-col gap-1 overflow-y-auto"
+      className="w-64 bg-card border-r border-border p-4 flex flex-col gap-1 overflow-y-auto"
       aria-label="Tag filter"
     >
       <SidebarRow
@@ -53,7 +53,7 @@ export default function TagSidebar({
         onClick={() => { setSelectedTagId(null); }}
       />
       {mode === "facets" && visibleTags.length === 0 && (
-        <p className="px-2 py-1.5 text-xs text-gray-500 italic">
+        <p className="px-3 py-1.5 caption text-muted-foreground italic">
           No tags in current results
         </p>
       )}
@@ -82,10 +82,10 @@ function SidebarRow({
   onClick: () => void;
 }) {
   const base =
-    "flex items-center justify-between px-2 py-1.5 text-sm rounded cursor-pointer transition-colors";
-  const activeCls = "bg-blue-600 text-white";
-  const inactiveCls = "text-gray-300 hover:bg-gray-700";
-  const countCls = active ? "text-blue-200" : "text-gray-400";
+    "flex items-center justify-between w-full rounded-md px-3 py-1.5 text-sm cursor-pointer transition-colors duration-micro ease-perima focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+  const activeCls = "bg-accent text-accent-foreground";
+  const inactiveCls = "text-foreground hover:bg-muted";
+  const countCls = active ? "text-accent-foreground" : "text-muted-foreground";
   return (
     <button
       type="button"
@@ -95,7 +95,7 @@ function SidebarRow({
     >
       <span className="truncate">{label}</span>
       {count !== undefined && (
-        <span className={`text-xs ml-2 ${countCls}`}>{count}</span>
+        <span className={`text-xs ml-2 tabular-nums ${countCls}`}>{count}</span>
       )}
     </button>
   );

--- a/apps/desktop/src/components/ThemeToggle.tsx
+++ b/apps/desktop/src/components/ThemeToggle.tsx
@@ -1,0 +1,46 @@
+/**
+ * Three-state theme cycle button. dark → light → system → dark.
+ * Icon shows the CURRENT mode; click advances to the next.
+ *
+ * WHY no useMemo on the icon map: React Compiler 1.0 handles memoization
+ * automatically (CLAUDE.md, Batch H — manual useMemo banned).
+ */
+import { MoonIcon, SunIcon, MonitorIcon } from "@phosphor-icons/react";
+import { useTheme, type Theme } from "../lib/theme-provider";
+
+const NEXT: Record<Theme, Theme> = {
+  dark: "light",
+  light: "system",
+  system: "dark",
+};
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const next = NEXT[theme];
+
+  let Icon = MoonIcon;
+  let label = "Theme: dark (click for light)";
+  if (theme === "light") {
+    Icon = SunIcon;
+    label = "Theme: light (click for system)";
+  } else if (theme === "system") {
+    Icon = MonitorIcon;
+    label = "Theme: system (click for dark)";
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => { setTheme(next); }}
+      aria-label={label}
+      className="inline-flex items-center justify-center rounded-full p-1.5
+                 bg-secondary text-secondary-foreground hover:bg-popover
+                 transition-colors duration-micro ease-perima
+                 focus-visible:outline-none focus-visible:ring-2
+                 focus-visible:ring-ring focus-visible:ring-offset-2
+                 focus-visible:ring-offset-background"
+    >
+      <Icon size={18} weight="regular" />
+    </button>
+  );
+}

--- a/apps/desktop/src/components/ViewModeToggle.tsx
+++ b/apps/desktop/src/components/ViewModeToggle.tsx
@@ -25,6 +25,8 @@ export default function ViewModeToggle() {
         aria-label="Grid view"
         className={`inline-flex items-center justify-center rounded-full px-3 py-1
                     transition-colors duration-micro ease-perima
+                    focus-visible:outline-none focus-visible:ring-2
+                    focus-visible:ring-ring focus-visible:ring-offset-0
                     ${viewMode === "grid"
                       ? "bg-accent text-accent-foreground"
                       : "text-muted-foreground hover:text-foreground"}`}
@@ -38,6 +40,8 @@ export default function ViewModeToggle() {
         aria-label="Table view"
         className={`inline-flex items-center justify-center rounded-full px-3 py-1
                     transition-colors duration-micro ease-perima
+                    focus-visible:outline-none focus-visible:ring-2
+                    focus-visible:ring-ring focus-visible:ring-offset-0
                     ${viewMode === "table"
                       ? "bg-accent text-accent-foreground"
                       : "text-muted-foreground hover:text-foreground"}`}

--- a/apps/desktop/src/components/ViewModeToggle.tsx
+++ b/apps/desktop/src/components/ViewModeToggle.tsx
@@ -1,3 +1,4 @@
+import { GridFourIcon, ListIcon } from "@phosphor-icons/react";
 import { useUiStore } from "../stores/ui";
 
 /**
@@ -5,37 +6,43 @@ import { useUiStore } from "../stores/ui";
  * Reads + dispatches viewMode via the Zustand store.
  *
  * WHY segmented control (not a single button that flips): two explicit
- * labels make the inactive option discoverable at a glance and match
+ * options make the inactive choice discoverable at a glance and match
  * desktop convention (Finder/Files-style switchers).
  */
 export default function ViewModeToggle() {
   const viewMode = useUiStore((s) => s.viewMode);
   const setViewMode = useUiStore((s) => s.setViewMode);
-  const base =
-    "px-3 py-1.5 text-sm font-medium rounded transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500";
-  const active = "bg-blue-600 text-white";
-  const inactive = "bg-gray-700 text-gray-200 hover:bg-gray-600";
   return (
     <div
-      className="inline-flex items-center gap-1 bg-gray-900 rounded p-0.5"
+      className="inline-flex items-center rounded-full bg-secondary p-0.5"
       role="group"
       aria-label="View mode"
     >
       <button
         type="button"
-        className={`${base} ${viewMode === "table" ? active : inactive}`}
-        aria-pressed={viewMode === "table"}
-        onClick={() => { setViewMode("table"); }}
+        onClick={() => { setViewMode("grid"); }}
+        aria-pressed={viewMode === "grid"}
+        aria-label="Grid view"
+        className={`inline-flex items-center justify-center rounded-full px-3 py-1
+                    transition-colors duration-micro ease-perima
+                    ${viewMode === "grid"
+                      ? "bg-accent text-accent-foreground"
+                      : "text-muted-foreground hover:text-foreground"}`}
       >
-        Table
+        <GridFourIcon size={16} weight="regular" />
       </button>
       <button
         type="button"
-        className={`${base} ${viewMode === "grid" ? active : inactive}`}
-        aria-pressed={viewMode === "grid"}
-        onClick={() => { setViewMode("grid"); }}
+        onClick={() => { setViewMode("table"); }}
+        aria-pressed={viewMode === "table"}
+        aria-label="Table view"
+        className={`inline-flex items-center justify-center rounded-full px-3 py-1
+                    transition-colors duration-micro ease-perima
+                    ${viewMode === "table"
+                      ? "bg-accent text-accent-foreground"
+                      : "text-muted-foreground hover:text-foreground"}`}
       >
-        Grid
+        <ListIcon size={16} weight="regular" />
       </button>
     </div>
   );

--- a/apps/desktop/src/lib/theme-provider.tsx
+++ b/apps/desktop/src/lib/theme-provider.tsx
@@ -1,0 +1,124 @@
+/**
+ * Theme provider for dark / light / system mode.
+ *
+ * WHY raw localStorage (not Zustand persist mw): CLAUDE.md "Frontend
+ * state (Batch H)" forbids `persist` middleware on the Zustand UI store
+ * because that store holds ephemeral app state (search query, scan
+ * status, notifications) that should NOT survive restarts. Theme is a
+ * user setting, different category — persisting it is correct.
+ * Implementing it via raw localStorage inside this provider keeps the
+ * existing rule intact.
+ *
+ * WHY effectiveTheme exposed even though no consumer reads it this slice:
+ * future component-level reads (e.g. Phosphor weight switching on
+ * resolved theme) without re-deriving from theme + matchMedia. Marked
+ * here so the implementer doesn't drop it as dead code.
+ *
+ * WHY systemTheme as separate state (not derived in render): we need to
+ * subscribe to matchMedia "change" events and re-render when the OS pref
+ * changes. Derived computation alone does not re-render on OS change.
+ * effectiveTheme is then a pure derivation: theme === "system" ?
+ * systemTheme : theme. No setState inside an effect body.
+ */
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type Theme = "dark" | "light" | "system";
+export type EffectiveTheme = "dark" | "light";
+
+interface ThemeContextValue {
+  theme: Theme;
+  effectiveTheme: EffectiveTheme;
+  setTheme: (theme: Theme) => void;
+}
+
+const STORAGE_KEY = "perima-theme";
+
+function readStoredTheme(): Theme {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw === "dark" || raw === "light" || raw === "system") return raw;
+  } catch {
+    // localStorage unavailable (private mode, SSR) — fall through.
+  }
+  return "system";
+}
+
+function getSystemTheme(): EffectiveTheme {
+  if (typeof window === "undefined") return "dark";
+  return window.matchMedia("(prefers-color-scheme: light)").matches
+    ? "light"
+    : "dark";
+}
+
+function applyEffectiveTheme(effective: EffectiveTheme): void {
+  if (typeof document === "undefined") return;
+  if (effective === "light") {
+    document.documentElement.setAttribute("data-theme", "light");
+  } else {
+    document.documentElement.removeAttribute("data-theme");
+  }
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+/** Provides dark/light/system theme switching with localStorage persistence. */
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => readStoredTheme());
+  // WHY separate systemTheme state: subscribing to matchMedia "change"
+  // events requires a stateful update path. effectiveTheme is then a
+  // pure render-time derivation (no setState in useEffect body).
+  const [systemTheme, setSystemTheme] = useState<EffectiveTheme>(() =>
+    getSystemTheme(),
+  );
+
+  // Listen to OS-level pref changes; update systemTheme via event callback
+  // (not synchronously inside the effect body — avoids react-hooks/set-state-in-effect).
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mql = window.matchMedia("(prefers-color-scheme: light)");
+    const handler = (e: MediaQueryListEvent) => {
+      setSystemTheme(e.matches ? "light" : "dark");
+    };
+    mql.addEventListener("change", handler);
+    return () => { mql.removeEventListener("change", handler); };
+  }, []);
+
+  // Derive effectiveTheme at render time — no effect needed.
+  const effectiveTheme: EffectiveTheme =
+    theme === "system" ? systemTheme : theme;
+
+  // Sync data-theme attribute to the DOM whenever effectiveTheme changes.
+  useEffect(() => {
+    applyEffectiveTheme(effectiveTheme);
+  }, [effectiveTheme]);
+
+  const setTheme = (next: Theme) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // localStorage unavailable — theme still updates in-memory.
+    }
+    setThemeState(next);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, effectiveTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+/** Returns the current theme context. Must be used within {@link ThemeProvider}. */
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (ctx === null) {
+    throw new Error("useTheme must be used within <ThemeProvider>");
+  }
+  return ctx;
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -4,15 +4,25 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "@tanstack/react-router";
 import { queryClient } from "./lib/queryClient";
 import { router } from "./router";
-import "./App.css";
+import { ThemeProvider } from "./lib/theme-provider";
+
+// WHY this import order: fonts.ts emits @font-face rules (side-effect
+// import) that tokens.css's --font-display / --font-sans / --font-mono
+// reference. tokens.css MUST come AFTER fonts.ts so font-face rules
+// are registered first. Reversing the order falls back to next font
+// in stack on first paint.
+import "./styles/fonts";
+import "./styles/tokens.css";
 
 const rootEl = document.getElementById("root");
 if (!rootEl) throw new Error("Root element not found");
 
 createRoot(rootEl).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    </ThemeProvider>
   </StrictMode>,
 );

--- a/apps/desktop/src/router.tsx
+++ b/apps/desktop/src/router.tsx
@@ -20,6 +20,7 @@ import {
 import App from "./App";
 import IndexRoute from "./routes/index";
 import DedupRoute from "./routes/dedup";
+import TypeRoute from "./routes/type";
 
 const rootRoute = createRootRoute({
   component: () => <App><Outlet /></App>,
@@ -40,7 +41,13 @@ const dedupRoute = createRoute({
   component: DedupRoute,
 });
 
-const routeTree = rootRoute.addChildren([indexRoute, dedupRoute]);
+const typeRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/type",
+  component: TypeRoute,
+});
+
+const routeTree = rootRoute.addChildren([indexRoute, dedupRoute, typeRoute]);
 
 export const router = createRouter({
   routeTree,

--- a/apps/desktop/src/routes/dedup.tsx
+++ b/apps/desktop/src/routes/dedup.tsx
@@ -84,13 +84,13 @@ function GroupRow({ group, onVerify, isVerifying }: GroupRowProps) {
 
   return (
     <div
-      className="border border-gray-700 rounded mb-2 bg-gray-900 p-3"
+      className="bg-card rounded-md shadow-e1 p-4 mb-3 border border-border"
       data-testid="dedup-group-row"
     >
       <header className="flex items-center justify-between mb-2">
-        <div className="text-sm text-gray-200 font-medium">
+        <div className="text-sm text-foreground font-medium">
           Candidate group — {fileCount} file{fileCount === 1 ? "" : "s"}, {sizeLabel} each
-          <span className="text-xs text-gray-400 ml-2">
+          <span className="text-xs text-muted-foreground ml-2">
             {group.quick_hash.slice(0, 12)}…{stateLabel}
           </span>
         </div>
@@ -98,21 +98,21 @@ function GroupRow({ group, onVerify, isVerifying }: GroupRowProps) {
           type="button"
           onClick={onVerify}
           disabled={isVerifying}
-          className="px-2 py-1 text-xs rounded bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="inline-flex items-center justify-center rounded-full px-3 py-1 text-xs font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors duration-micro disabled:opacity-40 disabled:pointer-events-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
           {isVerifying ? "Verifying…" : "Verify this group"}
         </button>
       </header>
-      <ul className="space-y-1 pl-2 text-xs font-mono text-gray-300">
+      <ul className="space-y-1 pl-2 mono-metadata text-foreground">
         {group.files.map((f: FileLocationRecord) => (
           <li
             key={f.file_uuid}
             title={`${f.volume_id}/${f.relative_path}`}
             className="truncate"
           >
-            <span className="text-gray-500">{f.volume_id.slice(0, 6)}/</span>
+            <span className="text-muted-foreground">{f.volume_id.slice(0, 6)}/</span>
             {basename(f.relative_path)}
-            <span className="text-gray-600"> ({f.relative_path})</span>
+            <span className="text-muted-foreground"> ({f.relative_path})</span>
           </li>
         ))}
       </ul>
@@ -191,7 +191,7 @@ export default function DedupRoute() {
   // ── Render branches ────────────────────────────────────────────────────
   if (isLoading) {
     return (
-      <div className="flex-1 p-8 text-gray-400">
+      <div className="flex-1 p-8 bg-background text-muted-foreground">
         <p>Loading candidate groups…</p>
       </div>
     );
@@ -199,7 +199,7 @@ export default function DedupRoute() {
 
   if (error) {
     return (
-      <div className="flex-1 p-8 text-red-400">
+      <div className="flex-1 p-8 bg-background text-destructive">
         <p>Failed to load candidate groups: [{error.kind}]</p>
       </div>
     );
@@ -207,7 +207,7 @@ export default function DedupRoute() {
 
   if (groups.length === 0) {
     return (
-      <div className="flex-1 p-8 text-gray-400" data-testid="dedup-empty-state">
+      <div className="flex-1 p-8 bg-background text-muted-foreground" data-testid="dedup-empty-state">
         <p>No candidate duplicates.</p>
       </div>
     );
@@ -231,15 +231,15 @@ export default function DedupRoute() {
   const totalSize = virtualizer.getTotalSize();
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden p-4">
-      <header className="mb-3 flex items-center justify-between">
-        <h1 className="text-lg font-semibold text-gray-100">
+    <div className="flex-1 flex flex-col overflow-hidden bg-background p-6">
+      <header className="mb-6 flex items-center justify-between">
+        <h1 className="text-lg font-semibold text-foreground">
           Candidate duplicate groups ({groups.length})
         </h1>
         <div className="flex items-center gap-2">
           {progressLabel && (
             <span
-              className="text-xs text-blue-300"
+              className="text-xs text-info"
               data-testid="dedup-progress-label"
             >
               {progressLabel}
@@ -250,7 +250,7 @@ export default function DedupRoute() {
               type="button"
               onClick={handleCancel}
               disabled={cancelMutation.isPending}
-              className="px-3 py-1.5 text-xs rounded bg-red-700 text-white hover:bg-red-600 disabled:opacity-50"
+              className="inline-flex items-center justify-center rounded-full px-3 py-1 text-xs font-medium bg-destructive text-destructive-foreground hover:opacity-90 transition-opacity duration-micro disabled:opacity-40 disabled:pointer-events-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               data-testid="dedup-cancel-button"
             >
               Cancel verify batch
@@ -260,7 +260,7 @@ export default function DedupRoute() {
             type="button"
             onClick={handleVerifyAll}
             disabled={verifyMutation.isPending || verifyBatch !== null}
-            className="px-3 py-1.5 text-xs rounded bg-amber-600 text-white hover:bg-amber-500 disabled:opacity-50"
+            className="inline-flex items-center justify-center rounded-full px-3 py-1 text-xs font-medium bg-warning text-warning-foreground hover:opacity-90 transition-opacity duration-micro disabled:opacity-40 disabled:pointer-events-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
             data-testid="dedup-verify-all-button"
             title="Slow — full hash on every candidate"
           >
@@ -270,7 +270,7 @@ export default function DedupRoute() {
       </header>
       <div
         ref={parentRef}
-        className="flex-1 overflow-auto rounded border border-gray-800"
+        className="flex-1 overflow-auto rounded-md border border-border"
         style={{ contain: "strict" }}
       >
         <div

--- a/apps/desktop/src/routes/index.tsx
+++ b/apps/desktop/src/routes/index.tsx
@@ -78,7 +78,7 @@ export default function IndexRoute() {
     : null;
 
   return (
-    <div className="flex-1 flex overflow-hidden">
+    <div className="flex h-full overflow-hidden bg-background">
       {tags.length > 0 && (
         <TagSidebar
           tags={tags}
@@ -87,11 +87,11 @@ export default function IndexRoute() {
           mode={searchActive ? "facets" : "all"}
         />
       )}
-      <main className="flex-1 overflow-auto p-4">
+      <section className="flex-1 min-w-0 overflow-y-auto">
         {viewMode === "table"
           ? <FileTable files={visibleFiles} loading={filesLoading} />
           : <FileGrid files={visibleFiles} loading={filesLoading} />}
-      </main>
+      </section>
       {selectedFile !== null && (
         <FileSidebar
           file={selectedFile}

--- a/apps/desktop/src/routes/type.tsx
+++ b/apps/desktop/src/routes/type.tsx
@@ -1,0 +1,141 @@
+/**
+ * Type-scale playground. Hidden route; no nav link; navigate manually
+ * via #/type. Survives shipping — useful for designer iteration, font
+ * swaps, color tweaks.
+ *
+ * WHY enumerated swatch class strings (not `bg-${name}` template literals):
+ * Tailwind v4's JIT scans source for full class-name strings at build time.
+ * Dynamic `bg-${name}` produces no utilities. Each SWATCHES entry pairs the
+ * variable name (for the label) with the literal utility class so the JIT
+ * picks it up.
+ *
+ * WHY border / input / ring rendered as swatches alongside surface colors:
+ * these tokens are alpha-low hairlines (rgba(255,255,255,0.08) in dark) so
+ * the swatches will look near-invisible against bg-card border chrome.
+ * Intentional — it's a designer-debugging surface, not production UI;
+ * seeing them disappear confirms the alpha is at the intended low value.
+ */
+import { useTheme } from "../lib/theme-provider";
+
+const SCALE = [
+  { cls: "display-xl", label: ".display-xl", text: "Painless library", meta: "Fraunces / 4.5rem / opsz 144" },
+  { cls: "h1",         label: ".h1",         text: "Your archive at peace", meta: "Fraunces / 3.5rem / opsz 96" },
+  { cls: "h2",         label: ".h2",         text: "Section title", meta: "Fraunces / 2.5rem / opsz 48" },
+  { cls: "h3",         label: ".h3",         text: "Card title", meta: "Fraunces / 1.75rem / opsz 36" },
+  { cls: "h4",         label: ".h4",         text: "Subheading", meta: "Inter / 1.25rem" },
+  { cls: "",           label: "body",        text: "The quick brown fox jumps over the lazy dog.", meta: "Inter / 1rem / 1.55" },
+  { cls: "caption",    label: ".caption",    text: "Image caption", meta: "Inter / 0.875rem" },
+  { cls: "eyebrow",    label: ".eyebrow",    text: "Section label", meta: "Inter / 0.75rem / uppercase" },
+  { cls: "mono-metadata", label: ".mono-metadata", text: "/Users/perima/library/photo.jpg", meta: "JetBrains Mono / 0.875rem" },
+];
+
+const SWATCHES: ReadonlyArray<{ name: string; cls: string }> = [
+  { name: "background",             cls: "bg-background" },
+  { name: "foreground",             cls: "bg-foreground" },
+  { name: "card",                   cls: "bg-card" },
+  { name: "card-foreground",        cls: "bg-card-foreground" },
+  { name: "popover",                cls: "bg-popover" },
+  { name: "popover-foreground",     cls: "bg-popover-foreground" },
+  { name: "muted",                  cls: "bg-muted" },
+  { name: "muted-foreground",       cls: "bg-muted-foreground" },
+  { name: "primary",                cls: "bg-primary" },
+  { name: "primary-foreground",     cls: "bg-primary-foreground" },
+  { name: "secondary",              cls: "bg-secondary" },
+  { name: "secondary-foreground",   cls: "bg-secondary-foreground" },
+  { name: "accent",                 cls: "bg-accent" },
+  { name: "accent-foreground",      cls: "bg-accent-foreground" },
+  { name: "destructive",            cls: "bg-destructive" },
+  { name: "destructive-foreground", cls: "bg-destructive-foreground" },
+  { name: "success",                cls: "bg-success" },
+  { name: "warning",                cls: "bg-warning" },
+  { name: "info",                   cls: "bg-info" },
+  { name: "border",                 cls: "bg-border" },
+  { name: "input",                  cls: "bg-input" },
+  { name: "ring",                   cls: "bg-ring" },
+];
+
+const OPSZ = [9, 36, 48, 96, 144];
+const WEIGHTS = [400, 500, 600];
+
+export default function TypeRoute() {
+  const { theme, effectiveTheme } = useTheme();
+  return (
+    <div className="bg-background text-foreground p-8 min-h-screen overflow-y-auto">
+      <header className="mb-12">
+        <h1 className="h1 mb-2">Type playground</h1>
+        <p className="caption text-muted-foreground">
+          Theme: {theme} (resolved: {effectiveTheme}). Hidden route — not linked from nav.
+        </p>
+      </header>
+
+      <section className="mb-12">
+        <h2 className="h3 mb-6">Type scale</h2>
+        <div className="space-y-6">
+          {SCALE.map((row) => (
+            <div key={row.label} className="flex items-baseline gap-6 border-b border-border pb-4">
+              <span className="mono-metadata text-muted-foreground w-40 shrink-0">{row.label}</span>
+              <span className={`flex-1 ${row.cls}`}>{row.text}</span>
+              <span className="mono-metadata text-muted-foreground text-xs w-64 shrink-0 text-right">{row.meta}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mb-12">
+        <h2 className="h3 mb-6">Fraunces opsz × weight grid</h2>
+        <div className="grid grid-cols-5 gap-4">
+          {WEIGHTS.flatMap((w) =>
+            OPSZ.map((opsz) => (
+              <div key={`${w}-${opsz}`} className="bg-card rounded-md p-4 border border-border">
+                <div
+                  className="text-2xl"
+                  style={{
+                    fontFamily: "var(--font-display)",
+                    fontWeight: w,
+                    fontVariationSettings: `"opsz" ${opsz}`,
+                  }}
+                >
+                  Aa
+                </div>
+                <div className="mono-metadata text-muted-foreground text-xs mt-2">w{w} / opsz {opsz}</div>
+              </div>
+            )),
+          )}
+        </div>
+      </section>
+
+      <section className="mb-12">
+        <h2 className="h3 mb-6">Italic specimens</h2>
+        <p
+          className="text-3xl"
+          style={{
+            fontFamily: "var(--font-display)",
+            fontStyle: "italic",
+            fontVariationSettings: `"opsz" 96`,
+          }}
+        >
+          A library of moments, kept calmly.
+        </p>
+      </section>
+
+      <section className="mb-12">
+        <h2 className="h3 mb-6">Spectrum</h2>
+        <h2 className="text-spectrum h2 mb-6">Perima Spectrum</h2>
+        <div className="bg-spectrum h-24 rounded-md mb-3" />
+        <div className="bg-spectrum w-16 h-16 rounded-full" aria-label="Petal mark preview" />
+      </section>
+
+      <section>
+        <h2 className="h3 mb-6">Theme palette</h2>
+        <div className="grid grid-cols-4 gap-4">
+          {SWATCHES.map(({ name, cls }) => (
+            <div key={name} className="rounded-md border border-border overflow-hidden">
+              <div className={`h-16 ${cls}`} />
+              <div className="p-2 mono-metadata text-xs">--{name}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/desktop/src/styles/fonts.ts
+++ b/apps/desktop/src/styles/fonts.ts
@@ -1,0 +1,7 @@
+// Fontsource side-effect imports — registers @font-face rules for the
+// variable woff2 font files Vite bundles. Imported by main.tsx BEFORE
+// tokens.css so the @font-face declarations are registered before
+// tokens.css references them via --font-display / --font-sans / --font-mono.
+import "@fontsource-variable/fraunces";
+import "@fontsource-variable/inter";
+import "@fontsource-variable/jetbrains-mono";

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -1,0 +1,197 @@
+/* WHY @theme inline: Tailwind v4 utility-class values resolve at runtime
+ * via var(--*); bare @theme bakes literal values at build time and ignores
+ * [data-theme="light"] overrides. This is the canonical shadcn-tailwind-v4
+ * pattern (https://ui.shadcn.com/docs/tailwind-v4). */
+
+@import "tailwindcss";
+
+/* === Raw CSS variables — perima dark (default) === */
+:root {
+  --background: #0A0C0F;
+  --foreground: #F5F1EC;
+  --card: #12151A;
+  --card-foreground: #F5F1EC;
+  --popover: #191D24;
+  --popover-foreground: #F5F1EC;
+  --muted: #22272F;
+  --muted-foreground: rgba(245, 241, 236, 0.72);
+  --primary: #F26A4F;
+  --primary-foreground: #0A0C0F;
+  --secondary: #191D24;
+  --secondary-foreground: #F5F1EC;
+  --accent: rgba(242, 106, 79, 0.16);
+  --accent-foreground: #F5F1EC;
+  --border: rgba(255, 255, 255, 0.08);
+  --input: rgba(255, 255, 255, 0.08);
+  --ring: #F26A4F;
+  --destructive: #F26A4F;
+  --destructive-foreground: #0A0C0F;
+  --success: #4EC28B;
+  --success-foreground: #0A0C0F;
+  --warning: #F5B945;
+  --warning-foreground: #0A0C0F;
+  --info: #4A8BF5;
+  --info-foreground: #0A0C0F;
+
+  --shadow-e1: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-e2: 0 8px 24px rgba(0, 0, 0, 0.45);
+  --shadow-e3: 0 24px 64px rgba(0, 0, 0, 0.55);
+
+  /* Identity layer — referenced via var() directly, not utility-generated */
+  --perima-spectrum-blue:  #4A8BF5;
+  --perima-spectrum-aqua:  #5BE2C2;
+  --perima-spectrum-amber: #F5B945;
+  --perima-spectrum-coral: #F26A4F;
+  --perima-spectrum: linear-gradient(
+    135deg,
+    var(--perima-spectrum-blue)  0%,
+    var(--perima-spectrum-aqua)  35%,
+    var(--perima-spectrum-amber) 65%,
+    var(--perima-spectrum-coral) 100%
+  );
+}
+
+/* === Light theme overrides — color + shadow only === */
+/* Fonts/radii/motion are theme-invariant; spectrum is identity-invariant. */
+[data-theme="light"] {
+  --background: #FBF8F3;
+  --foreground: #141618;
+  --card: #FFFFFF;
+  --card-foreground: #141618;
+  --popover: #F5F1EC;
+  --popover-foreground: #141618;
+  --muted: #EAE4DA;
+  --muted-foreground: rgba(20, 22, 24, 0.72);
+  --primary: #F26A4F;
+  --primary-foreground: #FFFFFF;
+  --secondary: #EAE4DA;
+  --secondary-foreground: #141618;
+  --accent: rgba(242, 106, 79, 0.12);
+  --accent-foreground: #141618;
+  --border: rgba(20, 22, 24, 0.08);
+  --input: rgba(20, 22, 24, 0.08);
+  --ring: #F26A4F;
+  --destructive: #D8573E;
+  --destructive-foreground: #FFFFFF;
+  --shadow-e1: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-e2: 0 8px 24px rgba(0, 0, 0, 0.08);
+  --shadow-e3: 0 24px 64px rgba(0, 0, 0, 0.12);
+}
+
+/* === Tailwind v4 utility-class aliases === */
+@theme inline {
+  --color-background:           var(--background);
+  --color-foreground:           var(--foreground);
+  --color-card:                 var(--card);
+  --color-card-foreground:      var(--card-foreground);
+  --color-popover:              var(--popover);
+  --color-popover-foreground:   var(--popover-foreground);
+  --color-muted:                var(--muted);
+  --color-muted-foreground:     var(--muted-foreground);
+  --color-primary:              var(--primary);
+  --color-primary-foreground:   var(--primary-foreground);
+  --color-secondary:            var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-accent:               var(--accent);
+  --color-accent-foreground:    var(--accent-foreground);
+  --color-border:               var(--border);
+  --color-input:                var(--input);
+  --color-ring:                 var(--ring);
+  --color-destructive:          var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-success:              var(--success);
+  --color-success-foreground:   var(--success-foreground);
+  --color-warning:              var(--warning);
+  --color-warning-foreground:   var(--warning-foreground);
+  --color-info:                 var(--info);
+  --color-info-foreground:      var(--info-foreground);
+
+  --radius-sm: 8px;
+  --radius-md: 14px;
+  --radius-lg: 20px;
+  --radius-xl: 28px;
+
+  --shadow-e1: var(--shadow-e1);
+  --shadow-e2: var(--shadow-e2);
+  --shadow-e3: var(--shadow-e3);
+
+  --ease-perima:    cubic-bezier(0.22, 0.61, 0.36, 1);
+  --duration-micro: 180ms;
+  --duration-panel: 280ms;
+  --duration-page:  420ms;
+
+  --font-display: "Fraunces Variable", "Times New Roman", Georgia, serif;
+  --font-sans:    "Inter Variable", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --font-mono:    "JetBrains Mono Variable", ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+/* === Spectrum helpers — identity layer, not utility-generated === */
+.bg-spectrum   { background: var(--perima-spectrum); }
+.text-spectrum {
+  background: var(--perima-spectrum);
+  -webkit-background-clip: text;
+          background-clip: text;
+  color: transparent;
+}
+
+/* === Typography — semantic classes (Tailwind has no font-variation-settings utility) === */
+.display-xl {
+  font-family: var(--font-display);
+  font-size: 4.5rem;
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+  font-weight: 600;
+  font-variation-settings: "opsz" 144;
+  margin: 0;
+}
+.h1 {
+  font-family: var(--font-display);
+  font-size: 3.5rem;
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+  font-weight: 600;
+  font-variation-settings: "opsz" 96;
+  margin: 0;
+}
+.h2 {
+  font-family: var(--font-display);
+  font-size: 2.5rem;
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+  font-weight: 600;
+  font-variation-settings: "opsz" 48;
+  margin: 0;
+}
+.h3 {
+  font-family: var(--font-display);
+  font-size: 1.75rem;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  font-weight: 600;
+  font-variation-settings: "opsz" 36;
+  margin: 0;
+}
+.h4 {
+  font-family: var(--font-sans);
+  font-size: 1.25rem;
+  line-height: 1.2;
+  font-weight: 600;
+  margin: 0;
+}
+.eyebrow {
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.caption {
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  line-height: 1.55;
+}
+.mono-metadata {
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  line-height: 1.55;
+}


### PR DESCRIPTION
## Summary
- Tailwind v4 `@theme inline` token system; shadcn-compatible names
- ThemeProvider — dark / light / system, prefers-color-scheme aware, localStorage-persisted (NOT Zustand persist mw)
- Self-hosted variable fonts via `@fontsource-variable/{fraunces,inter,jetbrains-mono}`
- Tree-shaken icons via `@phosphor-icons/react`
- Main-screen rewrite: App shell + 11 components + 2 routes against new tokens
- New `/type` hidden route — type scale + opsz grid + spectrum + theme palette swatches

## Test plan
- [ ] CI green (Linux + macOS + Windows)
- [ ] `bun run build` clean
- [ ] `bun test` 100% pass
- [ ] `bun run lint` zero warnings
- [ ] `cargo nextest run -p perima-desktop` pass (no Rust touched, sanity)
- [ ] `just bindings` no specta drift
- [ ] `bun run tauri dev` boots cleanly; no console errors at startup
- [ ] App boots in dark mode; matches reference design at a glance
- [ ] Theme toggle: dark → light → system, each shows expected palette
- [ ] System mode picks up OS-level pref change while running
- [ ] Theme persists after `tauri dev` restart (localStorage)
- [ ] All 11 components render without layout breaks
- [ ] `#/type` route renders the full type scale + spectrum + opsz grid
- [ ] Fonts load (no FOUC; Fraunces serif visible on headings)
- [ ] Search / Scan / Backup / dedup all functional (no behavior regressions)
